### PR TITLE
[FEATURE #9, #10]: 인증/인가 과정에서 재사용할 JWT 유틸 모듈

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/payper/server/auth/AuthController.java
+++ b/src/main/java/com/payper/server/auth/AuthController.java
@@ -1,0 +1,67 @@
+package com.payper.server.auth;
+
+import com.payper.server.auth.dto.JoinRequest;
+import com.payper.server.auth.dto.LoginRequest;
+import com.payper.server.auth.dto.LoginSuccessResponse;
+import com.payper.server.auth.dto.ReissueSuccessResponse;
+import com.payper.server.auth.util.OAuthUserInfo;
+import com.payper.server.global.response.ApiResponse;
+import com.payper.server.user.UserService;
+import com.payper.server.user.entity.AuthType;
+import com.payper.server.user.entity.User;
+import com.payper.server.user.entity.UserRole;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/login") //로그인 시도 -> 필요하면 가입 -> 로그인
+    public ResponseEntity<ApiResponse<LoginSuccessResponse>> enroll(
+            @RequestBody LoginRequest loginRequest,
+            HttpServletResponse response
+    ) {
+        //OAuth 리소스 서버와 통신 문제 생기면 예외
+        OAuthUserInfo oauthUserInfo = authService.findOAuthUserInfo(
+                loginRequest.getOauthToken(),
+                AuthType.KAKAO
+        );
+
+        //유저가 inactive(밴, 정지) 되어있으면 예외
+        User user = authService.findOrEnrollOAuthUser(oauthUserInfo);
+
+        String accessToken = authService.enrollNewAuthTokens(user, response);
+
+        return ResponseEntity.ok(ApiResponse.ok(new LoginSuccessResponse(accessToken)));
+    }
+
+
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponse<ReissueSuccessResponse>> reissue(
+            @CookieValue(required = false) String refreshToken,
+            HttpServletResponse response
+    ) {
+        String accessToken = authService.reissueAccessToken(refreshToken, response);
+
+        return ResponseEntity.ok(
+                ApiResponse.ok(new ReissueSuccessResponse(accessToken))
+        );
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<String>> logout(
+            @CookieValue(required = false) String refreshToken,
+            HttpServletResponse response
+    ) {
+        authService.clearRefreshTokenAndEntity(refreshToken, response);
+
+        return ResponseEntity.ok(ApiResponse.ok("logout success"));
+    }
+}

--- a/src/main/java/com/payper/server/auth/AuthGlobalExceptionHandler.java
+++ b/src/main/java/com/payper/server/auth/AuthGlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.payper.server.auth;
+
+import com.payper.server.auth.exception.OAuthException;
+import com.payper.server.auth.exception.UserAuthenticationException;
+import com.payper.server.auth.jwt.exception.ReissueException;
+import com.payper.server.global.response.ApiResponse;
+import com.payper.server.global.response.ErrorCode;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(
+        assignableTypes = {
+                AuthController.class,
+        }
+)
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class AuthGlobalExceptionHandler {
+
+    @ExceptionHandler(OAuthException.class)
+    public ResponseEntity<ApiResponse<Void>> handleOAuthException(final OAuthException exception) {
+        return buildErrorResponse(exception.getErrorCode());
+    }
+
+    @ExceptionHandler(UserAuthenticationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUserException(final UserAuthenticationException exception) {
+        return buildErrorResponse(exception.getErrorCode());
+    }
+
+    //AuthController 내에서 발생하는 JwtValidAuthentication 에러는 토큰 리이슈 관련 에러입니다.
+    @ExceptionHandler(ReissueException.class)
+    public ResponseEntity<ApiResponse<Void>> handleReissueException(
+            final ReissueException exception
+    ) {
+        return buildErrorResponse(exception.getErrorCode());
+    }
+
+
+    private ResponseEntity<ApiResponse<Void>> buildErrorResponse(ErrorCode errorCode) {
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode));
+    }
+}

--- a/src/main/java/com/payper/server/auth/AuthService.java
+++ b/src/main/java/com/payper/server/auth/AuthService.java
@@ -1,0 +1,146 @@
+package com.payper.server.auth;
+
+import com.payper.server.auth.dto.JoinRequest;
+import com.payper.server.auth.exception.OAuthException;
+import com.payper.server.auth.jwt.entity.JwtType;
+import com.payper.server.auth.jwt.entity.RefreshTokenEntity;
+import com.payper.server.auth.jwt.exception.JwtValidAuthenticationException;
+import com.payper.server.auth.jwt.exception.ReissueException;
+import com.payper.server.auth.jwt.util.JwtParseUtil;
+import com.payper.server.auth.jwt.util.JwtRefreshTokenUtil;
+import com.payper.server.auth.jwt.util.JwtTokenUtil;
+import com.payper.server.auth.util.KakaoOAuthUtilImpl;
+import com.payper.server.auth.util.OAuthUserInfo;
+import com.payper.server.global.response.ErrorCode;
+import com.payper.server.user.UserService;
+import com.payper.server.user.entity.AuthType;
+import com.payper.server.user.entity.User;
+import com.payper.server.user.entity.UserRole;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.Date;
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class AuthService {
+    private final UserService userService;
+    private final KakaoOAuthUtilImpl kakaoOAuthUtil;
+
+    private final JwtTokenUtil jwtTokenUtil;
+    private final JwtRefreshTokenUtil jwtRefreshTokenUtil;
+    private final JwtParseUtil jwtParseUtil;
+
+    public User findOrEnrollOAuthUser(OAuthUserInfo oauthUserInfo) {
+        //먼저 검증
+        Optional<User> user = userService.getActiveOAuthUser(oauthUserInfo);
+
+        return user.orElseGet(
+                () -> userService.save(
+                        User.create(
+                                AuthType.KAKAO,
+                                oauthUserInfo.getName(),
+                                oauthUserInfo.getOauthId(),
+                                UserRole.USER,
+                                true
+                        )
+                )
+        );
+    }
+
+    public OAuthUserInfo findOAuthUserInfo(String oauthToken, AuthType authType) {
+        return switch (authType) {
+            case AuthType.KAKAO -> kakaoOAuthUtil.getUserInfoFromOAuthToken(oauthToken);
+            default -> throw new OAuthException(ErrorCode.OAUTH_RESOURCE_ERROR);
+        };
+    }
+
+
+    public String enrollNewAuthTokens(User user, HttpServletResponse response) {
+        Date issuedAt = new Date();
+        upsertRefreshTokenAndEntity(user.getUserIdentifier(), response, issuedAt);
+        return upsertAccessToken(user.getUserIdentifier(), issuedAt);
+    }
+
+    public String reissueAccessToken(String refreshToken, HttpServletResponse response) {
+        /* 1. 있는데, 만료되지 않음 -> 정상처리
+         * 2. 있는데, 만료됨 -> 정상 리프레시 만료
+         * 3. 없는데, 만료되지 않음 -> 리플레이 어택
+         * 4. 없는데, 만료됨 -> 리플레이 어택
+         * 5. 그냥 토큰이 이상함
+         * */
+
+        if (!StringUtils.hasText(refreshToken)) {
+            throw new ReissueException(ErrorCode.JWT_REISSUE_ERROR);
+        }
+
+        // 1) JWT 자체 검증(서명/만료/형식) + 타입 검사
+        final String userIdentifier;
+        final JwtType jwtType;
+        try {
+            jwtType = jwtParseUtil.getJwtType(refreshToken);
+            if (jwtType != JwtType.REFRESH) {
+                throw new ReissueException(ErrorCode.JWT_REISSUE_ERROR);
+            }
+            userIdentifier = jwtParseUtil.getUserIdentifier(refreshToken);
+        } catch (JwtValidAuthenticationException e) {
+            throw
+                    switch (e.getErrorCode()) {
+                        case JWT_ERROR -> new ReissueException(ErrorCode.JWT_REISSUE_ERROR);
+                        case JWT_EXPIRED -> new ReissueException(ErrorCode.JWT_REISSUE_EXPIRED);
+                        default -> new ReissueException(ErrorCode.REISSUE_ERROR);
+                    };
+        }
+
+        // 2) DB에 없으면 리플레이 공격 의심 -> 해당 유저 토큰 전부 폐기
+        Optional<RefreshTokenEntity> refreshTokenEntity = jwtRefreshTokenUtil.getRefreshTokenEntity(refreshToken);
+        refreshTokenEntity.ifPresentOrElse(
+                (r) -> {
+                },
+                () -> {
+                    jwtRefreshTokenUtil.deleteAllRefreshTokenEntity(userIdentifier);
+                    throw new ReissueException(ErrorCode.JWT_REISSUE_OLD);
+                }
+        );
+
+        upsertRefreshTokenAndEntity(userIdentifier, response, jwtParseUtil.getIssuedAt(refreshToken));
+        return upsertAccessToken(userIdentifier, new Date());
+    }
+
+    private String upsertAccessToken(String userIdentifier, Date issuedAt) {
+        return jwtTokenUtil.generateJwtToken(JwtType.ACCESS, issuedAt, userIdentifier);
+    }
+
+    private void upsertRefreshTokenAndEntity(String userIdentifier, HttpServletResponse response, Date issuedAt) {
+        String refreshToken = jwtTokenUtil.generateJwtToken(JwtType.REFRESH, issuedAt, userIdentifier);
+
+        RefreshTokenEntity refreshTokenEntity =
+                jwtRefreshTokenUtil.generateRefreshTokenEntity(userIdentifier, refreshToken);
+
+
+        jwtRefreshTokenUtil.generateCookieRefreshToken(refreshToken, response);
+
+        jwtRefreshTokenUtil.upsertRefreshTokenEntity(refreshTokenEntity);
+    }
+
+    public void clearRefreshTokenAndEntity(String refreshToken, HttpServletResponse response) {
+        jwtRefreshTokenUtil.eraseCookieRefreshToken(response);
+
+        if (!StringUtils.hasText(refreshToken)) {
+            return;
+        }
+
+        Optional<RefreshTokenEntity> refreshTokenEntity = jwtRefreshTokenUtil.getRefreshTokenEntity(refreshToken);
+        refreshTokenEntity.ifPresent(
+                r ->
+                        jwtRefreshTokenUtil.deleteAllRefreshTokenEntity(r.getUserIdentifier())
+        );
+    }
+}

--- a/src/main/java/com/payper/server/auth/dto/JoinRequest.java
+++ b/src/main/java/com/payper/server/auth/dto/JoinRequest.java
@@ -1,10 +1,12 @@
 package com.payper.server.auth.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class JoinRequest {
+    @NotBlank(message="OAuth Provider가 제공한 oauth resource access token이 필요합니다.")
     private String oauthToken;
 }

--- a/src/main/java/com/payper/server/auth/dto/LoginRequest.java
+++ b/src/main/java/com/payper/server/auth/dto/LoginRequest.java
@@ -1,10 +1,13 @@
 package com.payper.server.auth.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class LoginRequest {
+
+    @NotBlank(message="OAuth Provider가 제공한 oauth resource access token이 필요합니다.")
     private String oauthToken;
 }

--- a/src/main/java/com/payper/server/auth/exception/UserAuthenticationException.java
+++ b/src/main/java/com/payper/server/auth/exception/UserAuthenticationException.java
@@ -5,10 +5,10 @@ import lombok.Getter;
 import org.springframework.security.core.AuthenticationException;
 
 @Getter
-public class MemberAuthenticationException extends AuthenticationException {
+public class UserAuthenticationException extends AuthenticationException {
     private final ErrorCode errorCode;
 
-    public MemberAuthenticationException(ErrorCode errorCode) {
+    public UserAuthenticationException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }

--- a/src/main/java/com/payper/server/auth/jwt/RefreshTokenRepository.java
+++ b/src/main/java/com/payper/server/auth/jwt/RefreshTokenRepository.java
@@ -1,5 +1,6 @@
 package com.payper.server.auth.jwt;
 
+import com.payper.server.auth.jwt.entity.RefreshTokenEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/com/payper/server/auth/jwt/entity/JwtType.java
+++ b/src/main/java/com/payper/server/auth/jwt/entity/JwtType.java
@@ -1,0 +1,5 @@
+package com.payper.server.auth.jwt.entity;
+
+public enum JwtType {
+    ACCESS,REFRESH
+}

--- a/src/main/java/com/payper/server/auth/jwt/entity/RefreshTokenEntity.java
+++ b/src/main/java/com/payper/server/auth/jwt/entity/RefreshTokenEntity.java
@@ -1,4 +1,4 @@
-package com.payper.server.auth.jwt;
+package com.payper.server.auth.jwt.entity;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/payper/server/auth/jwt/util/JwtParseUtil.java
+++ b/src/main/java/com/payper/server/auth/jwt/util/JwtParseUtil.java
@@ -4,6 +4,7 @@ import com.payper.server.auth.jwt.entity.JwtType;
 import com.payper.server.auth.jwt.exception.JwtValidAuthenticationException;
 import com.payper.server.global.response.ErrorCode;
 import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -76,7 +77,7 @@ public class JwtParseUtil {
                     .parseSignedClaims(jwtToken);
         } catch (ExpiredJwtException e) {
             throw new JwtValidAuthenticationException(ErrorCode.JWT_EXPIRED);
-        } catch (UnsupportedJwtException | ClaimJwtException |
+        } catch (UnsupportedJwtException | ClaimJwtException | SignatureException |
                  MalformedJwtException | IllegalArgumentException e) {
             throw new JwtValidAuthenticationException(ErrorCode.JWT_ERROR);
         }

--- a/src/main/java/com/payper/server/auth/jwt/util/JwtParseUtil.java
+++ b/src/main/java/com/payper/server/auth/jwt/util/JwtParseUtil.java
@@ -1,0 +1,84 @@
+package com.payper.server.auth.jwt.util;
+
+import com.payper.server.auth.jwt.entity.JwtType;
+import com.payper.server.auth.jwt.exception.JwtValidAuthenticationException;
+import com.payper.server.global.response.ErrorCode;
+import io.jsonwebtoken.*;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtParseUtil {
+    private final JwtProperties jwtProperties;
+    private SecretKey key;
+
+    @PostConstruct
+    protected void init() {
+        key = new SecretKeySpec(
+                jwtProperties.getSecretKey()
+                        .getBytes(StandardCharsets.UTF_8),
+                Jwts.SIG.HS512.key().build().getAlgorithm()
+        );
+    }
+
+    public String extractJwtTokenFromRequest(HttpServletRequest request) {
+        String headerValue = request.getHeader("Authorization");
+
+        if (StringUtils.hasText(headerValue) && headerValue.startsWith("Bearer ")) {
+            String token = headerValue.substring(7);
+
+            if (token.isEmpty())
+                return null;
+
+            return token;
+        }
+
+        return null;
+    }
+
+    public String getUserIdentifier(String jwtToken) {
+        return getClaimsFromJwtToken(jwtToken)
+                .getSubject();
+    }
+
+    public Date getIssuedAt(String jwtToken) {
+        return getClaimsFromJwtToken(jwtToken)
+                .getIssuedAt();
+    }
+
+    public Date getExpiresAt(String jwtToken) {
+        return getClaimsFromJwtToken(jwtToken)
+                .getExpiration();
+    }
+
+    public JwtType getJwtType(String jwtToken) {
+        return JwtType.valueOf(getJws(jwtToken).getHeader().getType());
+    }
+
+    private Claims getClaimsFromJwtToken(String jwtToken) {
+        return getJws(jwtToken).getPayload();
+    }
+
+    private Jws<Claims> getJws(String jwtToken) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(jwtToken);
+        } catch (ExpiredJwtException e) {
+            throw new JwtValidAuthenticationException(ErrorCode.JWT_EXPIRED);
+        } catch (UnsupportedJwtException | ClaimJwtException |
+                 MalformedJwtException | IllegalArgumentException e) {
+            throw new JwtValidAuthenticationException(ErrorCode.JWT_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/payper/server/auth/jwt/util/JwtProperties.java
+++ b/src/main/java/com/payper/server/auth/jwt/util/JwtProperties.java
@@ -1,0 +1,34 @@
+package com.payper.server.auth.jwt.util;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Getter
+@Component
+public class JwtProperties {
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+
+    @Value("${jwt.refresh-token.secret-key}")
+    private String refreshTokenSecretKey;
+
+    @Value("${jwt.access-token.exptime}")
+    @Getter(AccessLevel.NONE)
+    private Duration accessTokenExpiration;
+
+    @Value("${jwt.refresh-token.exptime}")
+    @Getter(AccessLevel.NONE)
+    private Duration refreshTokenExpiration;
+
+    public long getAccessTokenTime() {
+        return accessTokenExpiration.toMillis();
+    }
+
+    public long getRefreshTokenTime() {
+        return refreshTokenExpiration.toMillis();
+    }
+}

--- a/src/main/java/com/payper/server/auth/jwt/util/JwtRefreshTokenUtil.java
+++ b/src/main/java/com/payper/server/auth/jwt/util/JwtRefreshTokenUtil.java
@@ -81,7 +81,7 @@ public class JwtRefreshTokenUtil {
         Cookie cookie = new Cookie("refreshToken", refreshToken);
         cookie.setPath("/");
         cookie.setHttpOnly(true);
-        int age = (int) ((new Date()).getTime() - jwtParseUtil.getExpiresAt(refreshToken).getTime() / 1000);
+        int age = (int) ((jwtParseUtil.getExpiresAt(refreshToken).getTime() - new Date().getTime()) / 1000);
         cookie.setMaxAge(age);
         response.addCookie(cookie);
     }

--- a/src/main/java/com/payper/server/auth/jwt/util/JwtRefreshTokenUtil.java
+++ b/src/main/java/com/payper/server/auth/jwt/util/JwtRefreshTokenUtil.java
@@ -2,6 +2,8 @@ package com.payper.server.auth.jwt.util;
 
 import com.payper.server.auth.jwt.RefreshTokenRepository;
 import com.payper.server.auth.jwt.entity.RefreshTokenEntity;
+import com.payper.server.auth.jwt.exception.ReissueException;
+import com.payper.server.global.response.ErrorCode;
 import io.jsonwebtoken.Jwts;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.Cookie;
@@ -18,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.Base64;
 import java.util.Date;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -70,10 +73,9 @@ public class JwtRefreshTokenUtil {
         return count;
     }
 
-    public RefreshTokenEntity getRefreshTokenEntity(String refreshToken) {
+    public Optional<RefreshTokenEntity> getRefreshTokenEntity(String refreshToken) {
         return refreshTokenRepository
-                .findByHashedRefreshToken(hashRefreshToken(refreshToken))
-                .orElse(null);
+                .findByHashedRefreshToken(hashRefreshToken(refreshToken));
     }
 
 

--- a/src/main/java/com/payper/server/auth/jwt/util/JwtRefreshTokenUtil.java
+++ b/src/main/java/com/payper/server/auth/jwt/util/JwtRefreshTokenUtil.java
@@ -38,11 +38,11 @@ public class JwtRefreshTokenUtil {
     }
 
     public RefreshTokenEntity generateRefreshTokenEntity(
-            String memberIdentifier, String refreshToken
+            String userIdentifier, String refreshToken
     ) {
 
         return RefreshTokenEntity.create(
-                memberIdentifier,
+                userIdentifier,
                 hashRefreshToken(refreshToken)
         );
     }
@@ -64,8 +64,8 @@ public class JwtRefreshTokenUtil {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public int deleteAllRefreshTokenEntity(String memberIdentifier) {
-        int count = refreshTokenRepository.deleteByUserIdentifier(memberIdentifier);
+    public int deleteAllRefreshTokenEntity(String userIdentifier) {
+        int count = refreshTokenRepository.deleteByUserIdentifier(userIdentifier);
         refreshTokenRepository.flush();
         return count;
     }

--- a/src/main/java/com/payper/server/auth/jwt/util/JwtRefreshTokenUtil.java
+++ b/src/main/java/com/payper/server/auth/jwt/util/JwtRefreshTokenUtil.java
@@ -1,0 +1,96 @@
+package com.payper.server.auth.jwt.util;
+
+import com.payper.server.auth.jwt.RefreshTokenRepository;
+import com.payper.server.auth.jwt.entity.RefreshTokenEntity;
+import io.jsonwebtoken.Jwts;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtRefreshTokenUtil {
+    private final JwtProperties jwtProperties;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtParseUtil jwtParseUtil;
+
+    private SecretKey refreshSecretKey;
+
+    @PostConstruct
+    protected void init() {
+        refreshSecretKey = new SecretKeySpec(
+                jwtProperties.getRefreshTokenSecretKey()
+                        .getBytes(StandardCharsets.UTF_8),
+                Jwts.SIG.HS512.key().build().getAlgorithm()
+        );
+    }
+
+    public RefreshTokenEntity generateRefreshTokenEntity(
+            String memberIdentifier, String refreshToken
+    ) {
+
+        return RefreshTokenEntity.create(
+                memberIdentifier,
+                hashRefreshToken(refreshToken)
+        );
+    }
+
+    private String hashRefreshToken(String refreshToken) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(refreshSecretKey);
+            byte[] digest = mac.doFinal(refreshToken.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException("Failed to hash refresh token", e);
+        }
+    }
+
+    public void upsertRefreshTokenEntity(RefreshTokenEntity refreshTokenEntity) {
+        deleteAllRefreshTokenEntity(refreshTokenEntity.getUserIdentifier());
+        refreshTokenRepository.save(refreshTokenEntity);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public int deleteAllRefreshTokenEntity(String memberIdentifier) {
+        int count = refreshTokenRepository.deleteByUserIdentifier(memberIdentifier);
+        refreshTokenRepository.flush();
+        return count;
+    }
+
+    public RefreshTokenEntity getRefreshTokenEntity(String refreshToken) {
+        return refreshTokenRepository
+                .findByHashedRefreshToken(hashRefreshToken(refreshToken))
+                .orElse(null);
+    }
+
+
+    public void generateCookieRefreshToken(String refreshToken, HttpServletResponse response) {
+        Cookie cookie = new Cookie("refreshToken", refreshToken);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        int age = (int) ((new Date()).getTime() - jwtParseUtil.getExpiresAt(refreshToken).getTime() / 1000);
+        cookie.setMaxAge(age);
+        response.addCookie(cookie);
+    }
+
+    public void eraseCookieRefreshToken(HttpServletResponse response) {
+        Cookie cookie = new Cookie("refreshToken", null);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+    }
+}

--- a/src/main/java/com/payper/server/auth/jwt/util/JwtTokenUtil.java
+++ b/src/main/java/com/payper/server/auth/jwt/util/JwtTokenUtil.java
@@ -1,0 +1,50 @@
+package com.payper.server.auth.jwt.util;
+
+import com.payper.server.auth.jwt.entity.JwtType;
+import io.jsonwebtoken.*;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenUtil {
+    private final JwtProperties jwtProperties;
+
+    private SecretKey key;
+
+    @PostConstruct
+    protected void init() {
+        key = new SecretKeySpec(
+                jwtProperties.getSecretKey()
+                        .getBytes(StandardCharsets.UTF_8),
+                Jwts.SIG.HS512.key().build().getAlgorithm()
+        );
+    }
+
+    public String generateJwtToken(JwtType jwtType, Date now, String memberIdentifier) {
+        Date expDate = new Date(
+                now.getTime() +
+                        (jwtType == JwtType.REFRESH ?
+                                jwtProperties.getRefreshTokenTime() : jwtProperties.getAccessTokenTime())
+        );
+
+        return Jwts.builder()
+                .header()
+                .type(jwtType.name())
+                .and()
+                .subject(memberIdentifier)
+                .issuedAt(now)
+                .expiration(expDate)
+                .signWith(key)
+                .id(UUID.randomUUID().toString())
+                .compact();
+    }
+
+}

--- a/src/main/java/com/payper/server/auth/jwt/util/JwtTokenUtil.java
+++ b/src/main/java/com/payper/server/auth/jwt/util/JwtTokenUtil.java
@@ -28,7 +28,7 @@ public class JwtTokenUtil {
         );
     }
 
-    public String generateJwtToken(JwtType jwtType, Date now, String memberIdentifier) {
+    public String generateJwtToken(JwtType jwtType, Date now, String userIdentifier) {
         Date expDate = new Date(
                 now.getTime() +
                         (jwtType == JwtType.REFRESH ?
@@ -39,7 +39,7 @@ public class JwtTokenUtil {
                 .header()
                 .type(jwtType.name())
                 .and()
-                .subject(memberIdentifier)
+                .subject(userIdentifier)
                 .issuedAt(now)
                 .expiration(expDate)
                 .signWith(key)

--- a/src/main/java/com/payper/server/auth/util/KakaoOAuthUtilImpl.java
+++ b/src/main/java/com/payper/server/auth/util/KakaoOAuthUtilImpl.java
@@ -1,0 +1,65 @@
+package com.payper.server.auth.util;
+
+import com.payper.server.auth.exception.OAuthException;
+import com.payper.server.global.response.ErrorCode;
+import com.payper.server.user.entity.AuthType;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthUtilImpl implements OAuthUtil {
+    private static final String PROPERTY_KEYS = "[\"kakao_account.profile\"]";
+
+    private RestClient kakaoRestClient;
+    private final ObjectMapper objectMapper;
+
+    @PostConstruct
+    protected void init() {
+        kakaoRestClient=RestClient.builder()
+                .baseUrl("https://kapi.kakao.com")
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+
+    @Override
+    public OAuthUserInfo getUserInfoFromOAuthToken(String oAuthToken) {
+        String body = kakaoRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/v2/user/me")
+                        .queryParam("property_keys", PROPERTY_KEYS)
+                        .build())
+                .headers(headers -> headers.setBearerAuth(oAuthToken))
+                .retrieve()
+                .onStatus(
+                        HttpStatusCode::isError,
+                        (request, response) ->
+                        {
+                            throw new OAuthException(ErrorCode.OAUTH_RESOURCE_ERROR);
+                        }
+                )
+                .body(String.class);
+
+        try {
+            JsonNode json = objectMapper.readTree(body);
+
+            String name = json.path("kakao_account")
+                    .path("profile")
+                    .path("nickname")
+                    .asString();
+
+            String kakaoId = json.path("id").asString();
+
+            return new OAuthUserInfo(name, kakaoId, AuthType.KAKAO);
+        } catch (Exception e) {
+            throw new OAuthException(ErrorCode.OAUTH_RESOURCE_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/payper/server/auth/util/OAuthUserInfo.java
+++ b/src/main/java/com/payper/server/auth/util/OAuthUserInfo.java
@@ -1,0 +1,15 @@
+package com.payper.server.auth.util;
+
+import com.payper.server.user.entity.AuthType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OAuthUserInfo {
+    private String name;
+
+    private String oauthId;
+
+    private AuthType authType;
+}

--- a/src/main/java/com/payper/server/auth/util/OAuthUtil.java
+++ b/src/main/java/com/payper/server/auth/util/OAuthUtil.java
@@ -1,0 +1,5 @@
+package com.payper.server.auth.util;
+
+public interface OAuthUtil {
+    OAuthUserInfo getUserInfoFromOAuthToken(String oAuthToken);
+}

--- a/src/main/java/com/payper/server/domain/test/TestAuthController.java
+++ b/src/main/java/com/payper/server/domain/test/TestAuthController.java
@@ -1,0 +1,34 @@
+package com.payper.server.domain.test;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RestController
+public class TestAuthController {
+    @GetMapping("/")
+    public String index() {
+        return "Hello World";
+    }
+
+    @GetMapping("/me")
+    public String getMe(
+            Principal principal,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        System.out.println("principal.getName() = " + principal.getName());
+        System.out.println("userDetails.username() = " + userDetails.getUsername());
+        System.out.println("userDetails.password() = " + userDetails.getPassword());
+        System.out.println("userDetails.getAuthorities() = " + userDetails.getAuthorities());
+
+        return "Hello me";
+    }
+
+    @GetMapping("/admin")
+    public String admin() {
+        return "Hello Admin";
+    }
+}

--- a/src/main/java/com/payper/server/domain/test/TestController.java
+++ b/src/main/java/com/payper/server/domain/test/TestController.java
@@ -4,9 +4,13 @@ import com.payper.server.global.exception.ApiException;
 import com.payper.server.global.response.ApiResponse;
 import com.payper.server.global.response.ErrorCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
 
 @RestController
 @RequestMapping("/test")
@@ -30,4 +34,6 @@ public class TestController {
     public ResponseEntity<ApiResponse<Void>> testFailure3() throws Exception {
         throw new Exception();
     }
+
+
 }

--- a/src/main/java/com/payper/server/global/response/ErrorCode.java
+++ b/src/main/java/com/payper/server/global/response/ErrorCode.java
@@ -19,13 +19,16 @@ public enum ErrorCode {
     JWT_EXPIRED("JWT_002", HttpStatus.UNAUTHORIZED, "JWT Expired"),
     JWT_REISSUE_ERROR("JWT_003", HttpStatus.INTERNAL_SERVER_ERROR, "Refresh Token General Error"),
     JWT_REISSUE_EXPIRED("JWT_004", HttpStatus.INTERNAL_SERVER_ERROR, "Refresh Token Expired"),
-    REISSUE_ERROR("JWT_005", HttpStatus.INTERNAL_SERVER_ERROR, "Reissue General Error"),
+    JWT_REISSUE_OLD("JWT_005", HttpStatus.INTERNAL_SERVER_ERROR, "Refresh Token Is Old"),
+    REISSUE_ERROR("JWT_006", HttpStatus.INTERNAL_SERVER_ERROR, "Reissue General Error"),
 
     //AUTHENTICATION - GENERAL
     UNAUTHENTICATED("SEC-001", HttpStatus.UNAUTHORIZED, "Unauthenticated"),
     UNAUTHORIZED("SEC-002", HttpStatus.FORBIDDEN, "Unauthorized"),
     USER_DUPLICATE("SEC-003", HttpStatus.INTERNAL_SERVER_ERROR, "Duplicate User"),
     USER_NOTFOUND("SEC-004", HttpStatus.INTERNAL_SERVER_ERROR, "User Not Exists"),
+    USER_INACTIVE("SEC-005", HttpStatus.INTERNAL_SERVER_ERROR, "User Banned"),
+
     OAUTH_RESOURCE_ERROR("OAUTH-001", HttpStatus.SERVICE_UNAVAILABLE, "OAuth Resource Unavailable");
 
 

--- a/src/main/java/com/payper/server/global/response/ErrorCode.java
+++ b/src/main/java/com/payper/server/global/response/ErrorCode.java
@@ -24,8 +24,8 @@ public enum ErrorCode {
     //AUTHENTICATION - GENERAL
     UNAUTHENTICATED("SEC-001", HttpStatus.UNAUTHORIZED, "Unauthenticated"),
     UNAUTHORIZED("SEC-002", HttpStatus.FORBIDDEN, "Unauthorized"),
-    MEMBER_DUPLICATE("SEC-003", HttpStatus.INTERNAL_SERVER_ERROR, "Duplicate Member"),
-    MEMBER_NOTFOUND("SEC-004", HttpStatus.INTERNAL_SERVER_ERROR, "Member Not Exists"),
+    USER_DUPLICATE("SEC-003", HttpStatus.INTERNAL_SERVER_ERROR, "Duplicate User"),
+    USER_NOTFOUND("SEC-004", HttpStatus.INTERNAL_SERVER_ERROR, "User Not Exists"),
     OAUTH_RESOURCE_ERROR("OAUTH-001", HttpStatus.SERVICE_UNAVAILABLE, "OAuth Resource Unavailable");
 
 

--- a/src/main/java/com/payper/server/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/payper/server/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,49 @@
+package com.payper.server.security;
+
+import com.payper.server.global.response.ApiResponse;
+import com.payper.server.global.response.ErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException, ServletException {
+
+        ApiResponse<String> failResponseDto;
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if(authentication==null||!(authentication.isAuthenticated())) {
+            failResponseDto =
+                    ApiResponse.fail(ErrorCode.UNAUTHENTICATED, accessDeniedException.getMessage());
+        }
+        else{
+            failResponseDto =
+                    ApiResponse.fail(ErrorCode.UNAUTHORIZED, accessDeniedException.getMessage());
+        }
+
+        response.setStatus(failResponseDto.getStatus());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        objectMapper.writeValue(response.getWriter(), failResponseDto);
+    }
+}

--- a/src/main/java/com/payper/server/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/payper/server/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,68 @@
+package com.payper.server.security;
+
+import com.payper.server.auth.exception.UserAuthenticationException;
+import com.payper.server.auth.jwt.exception.JwtValidAuthenticationException;
+import com.payper.server.global.response.ApiResponse;
+import com.payper.server.global.response.ErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@RequiredArgsConstructor
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException, ServletException {
+
+        if (response.isCommitted()) {
+            return;
+        }
+
+        ErrorCode errorCode = resolveErrorCode(request, authException);
+
+        ApiResponse<Void> body = ApiResponse.fail(errorCode);
+
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        objectMapper.writeValue(response.getWriter(), body);
+    }
+
+    private ErrorCode resolveErrorCode(HttpServletRequest request, AuthenticationException ex) {
+
+        // 1) 내가 만든 커스텀 예외면 그대로 사용
+        if (ex instanceof JwtValidAuthenticationException jwtEx) {
+            return jwtEx.getErrorCode();
+        }
+        if(ex instanceof  UserAuthenticationException userEx) {
+            return userEx.getErrorCode();
+        }
+
+        // 3) 토큰이 아예 없거나(익명 접근) 등으로 발생하는 대표 케이스
+        if (ex instanceof InsufficientAuthenticationException) {
+            return ErrorCode.UNAUTHENTICATED;
+        }
+
+        // 4) 최후의 기본값
+        return ErrorCode.UNAUTHENTICATED;
+    }
+
+}

--- a/src/main/java/com/payper/server/security/CustomUserDetailsService.java
+++ b/src/main/java/com/payper/server/security/CustomUserDetailsService.java
@@ -1,0 +1,35 @@
+package com.payper.server.security;
+
+import com.payper.server.auth.exception.UserAuthenticationException;
+import com.payper.server.global.response.ErrorCode;
+import com.payper.server.user.UserRepository;
+import com.payper.server.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String userIdentifier) throws UsernameNotFoundException {
+        User activeUser = getActiveUserByUserIdentifier(userIdentifier);
+        return new CustomUserDetails(activeUser);
+    }
+
+    public User getActiveUserByUserIdentifier(String userIdentifier) {
+        User user = userRepository.findByUserIdentifier(userIdentifier)
+                .orElseThrow(() -> new UserAuthenticationException(ErrorCode.USER_NOTFOUND));
+
+        if (!user.isActive()) {
+            throw new UserAuthenticationException(ErrorCode.USER_NOTFOUND);
+        }
+        return user;
+    }
+}

--- a/src/main/java/com/payper/server/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/payper/server/security/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package com.payper.server.security;
+
+import com.payper.server.auth.jwt.util.JwtParseUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final RequestMatcher skipRequestMatcher;
+    private final JwtParseUtil jwtParseUtil;
+    private final AuthenticationManager authenticationManager;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return skipRequestMatcher.matches(request);
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        //System.out.println("JwtAuthenticationFilter.doFilterInternal");
+
+        String accessToken = jwtParseUtil.extractJwtTokenFromRequest(request);
+
+        if (accessToken == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try{
+            Authentication requestAuth =
+                    UsernamePasswordAuthenticationToken.unauthenticated(null, accessToken);
+
+            Authentication authenticated =
+                    authenticationManager.authenticate(requestAuth);
+            SecurityContextHolder.getContext().setAuthentication(authenticated);
+            filterChain.doFilter(request, response);
+        }
+        catch(AuthenticationException e){
+            SecurityContextHolder.clearContext();
+            customAuthenticationEntryPoint.commence(request, response, e);
+        }
+    }
+}

--- a/src/main/java/com/payper/server/security/JwtAuthenticationProvider.java
+++ b/src/main/java/com/payper/server/security/JwtAuthenticationProvider.java
@@ -1,0 +1,42 @@
+package com.payper.server.security;
+
+import com.payper.server.auth.jwt.entity.JwtType;
+import com.payper.server.auth.jwt.exception.JwtValidAuthenticationException;
+import com.payper.server.auth.jwt.util.JwtParseUtil;
+import com.payper.server.global.response.ErrorCode;
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+    private final UserDetailsService userDetailsService;
+    private final JwtParseUtil jwtParseUtil;
+
+    @Override
+    public @Nullable Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        String accessToken = (String) authentication.getCredentials();
+
+        if (jwtParseUtil.getJwtType(accessToken) != JwtType.ACCESS) {
+            throw new JwtValidAuthenticationException(ErrorCode.JWT_ERROR);
+        }
+
+        String userIdentifier = jwtParseUtil.getUserIdentifier(accessToken);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(userIdentifier);
+
+        return UsernamePasswordAuthenticationToken.authenticated(userDetails, null, userDetails.getAuthorities());
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}
+

--- a/src/main/java/com/payper/server/security/SecurityConfig.java
+++ b/src/main/java/com/payper/server/security/SecurityConfig.java
@@ -1,0 +1,96 @@
+package com.payper.server.security;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private RequestMatcher permitAllRequestMatcher;
+    private RequestMatcher authenticatedRequestMatcher;
+    private RequestMatcher adminRequestMatcher;
+
+    @PostConstruct
+    void init() {
+        var requestMatcher =
+                PathPatternRequestMatcher.withDefaults().basePath("/");
+
+        permitAllRequestMatcher = new OrRequestMatcher(
+                requestMatcher.matcher(HttpMethod.GET, "/swagger-ui/**"),
+                requestMatcher.matcher(HttpMethod.GET, "/v3/api-docs/**"),
+                requestMatcher.matcher(HttpMethod.GET, "/favicon.ico"),
+                requestMatcher.matcher("/auth/**")
+        );
+        authenticatedRequestMatcher = new OrRequestMatcher(
+                requestMatcher.matcher(HttpMethod.GET, "/me")
+        );
+        adminRequestMatcher = new OrRequestMatcher(
+                requestMatcher.matcher(HttpMethod.GET, "/admin/**")
+        );
+    }
+
+
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors((registry) -> registry.configurationSource(corsConfigurationSource()))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .rememberMe(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .sessionManagement(
+                        a -> a.sessionCreationPolicy(
+                                SessionCreationPolicy.STATELESS
+                        )
+                )
+
+                .authorizeHttpRequests(
+                        configurer -> configurer
+                                .requestMatchers(permitAllRequestMatcher)
+                                .permitAll()
+                                .requestMatchers(authenticatedRequestMatcher)
+                                .permitAll()
+                                .requestMatchers(adminRequestMatcher)
+                                .hasRole("ADMIN")
+                                .anyRequest().authenticated()
+                )
+
+
+                .build();
+    }
+
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.addAllowedOriginPattern("*");
+        configuration.addAllowedMethod("*");
+        configuration.addAllowedHeader("*");
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}

--- a/src/main/java/com/payper/server/security/SecurityConfig.java
+++ b/src/main/java/com/payper/server/security/SecurityConfig.java
@@ -1,21 +1,28 @@
 package com.payper.server.security;
 
+import com.payper.server.auth.jwt.util.JwtParseUtil;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import tools.jackson.databind.ObjectMapper;
 
 @Configuration
 @EnableWebSecurity
@@ -25,18 +32,26 @@ public class SecurityConfig {
     private RequestMatcher authenticatedRequestMatcher;
     private RequestMatcher adminRequestMatcher;
 
+    private final JwtAuthenticationProvider jwtAuthenticationProvider;
+    private final JwtParseUtil jwtParseUtil;
+
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
     @PostConstruct
     void init() {
         var requestMatcher =
                 PathPatternRequestMatcher.withDefaults().basePath("/");
 
         permitAllRequestMatcher = new OrRequestMatcher(
+                //requestMatcher.matcher("/**"),
                 requestMatcher.matcher(HttpMethod.GET, "/swagger-ui/**"),
                 requestMatcher.matcher(HttpMethod.GET, "/v3/api-docs/**"),
                 requestMatcher.matcher(HttpMethod.GET, "/favicon.ico"),
                 requestMatcher.matcher("/auth/**")
         );
         authenticatedRequestMatcher = new OrRequestMatcher(
+                //requestMatcher.matcher("/**"),
                 requestMatcher.matcher(HttpMethod.GET, "/me")
         );
         adminRequestMatcher = new OrRequestMatcher(
@@ -44,6 +59,28 @@ public class SecurityConfig {
         );
     }
 
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager() {
+        return new ProviderManager(
+                jwtAuthenticationProvider
+        );
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        RequestMatcher skipEndPoints = permitAllRequestMatcher;
+        return new JwtAuthenticationFilter(
+                skipEndPoints,
+                jwtParseUtil,
+                authenticationManager(),
+                customAuthenticationEntryPoint
+        );
+    }
 
 
     @Bean
@@ -66,12 +103,18 @@ public class SecurityConfig {
                                 .requestMatchers(permitAllRequestMatcher)
                                 .permitAll()
                                 .requestMatchers(authenticatedRequestMatcher)
-                                .permitAll()
+                                .authenticated()
                                 .requestMatchers(adminRequestMatcher)
                                 .hasRole("ADMIN")
-                                .anyRequest().authenticated()
                 )
 
+                .addFilterAfter(jwtAuthenticationFilter(), LogoutFilter.class)
+
+                .exceptionHandling(
+                        configurer -> configurer
+                                .authenticationEntryPoint(customAuthenticationEntryPoint)
+                                .accessDeniedHandler(customAccessDeniedHandler)
+                )
 
                 .build();
     }

--- a/src/main/java/com/payper/server/user/UserRepository.java
+++ b/src/main/java/com/payper/server/user/UserRepository.java
@@ -18,5 +18,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByOauthIdAndActive(String oauthId, boolean active);
 
-    Optional<User> findByOauthIdAndNameAndAuthType(String oauthId, String name, AuthType authType);
+    Optional<User> findByOauthIdAndAuthType(String oauthId, AuthType authType);
 }

--- a/src/main/java/com/payper/server/user/UserService.java
+++ b/src/main/java/com/payper/server/user/UserService.java
@@ -1,0 +1,56 @@
+package com.payper.server.user;
+
+import com.payper.server.auth.exception.UserAuthenticationException;
+import com.payper.server.auth.util.OAuthUserInfo;
+import com.payper.server.global.response.ErrorCode;
+import com.payper.server.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserService {
+    private final UserRepository userRepository;
+
+    public User save(final User user) {
+        return userRepository.save(user);
+    }
+
+    private void validateDuplicate(final User user) {
+        Optional<User> findUser = switch (user.getAuthType()) {
+            case KAKAO -> userRepository.findByOauthIdAndActive(user.getOauthId(), true);
+            default ->
+                    throw new IllegalArgumentException("Unsupported AuthType for duplicate validation: " + user.getAuthType());
+        };
+
+        if (findUser.isPresent()) {
+            throw new UserAuthenticationException(ErrorCode.USER_DUPLICATE);
+        }
+    }
+
+    public Optional<User> getActiveOAuthUser(OAuthUserInfo oAuthUserInfo) {
+        Optional<User> user =
+                userRepository.findByOauthIdAndAuthType(
+                        oAuthUserInfo.getOauthId(),
+                        oAuthUserInfo.getAuthType()
+                );
+
+        user.ifPresent(
+                u -> {
+                    if (!u.isActive()) {
+                        throw new UserAuthenticationException(ErrorCode.USER_INACTIVE);
+                    }
+                }
+        );
+
+        return user;
+    }
+
+    public void delete(final User user) {
+        userRepository.updateActiveById(false, user.getId());
+    }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -16,3 +16,11 @@ spring:
   sql:
     init:
       mode: never
+
+jwt:
+  secret-key: "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCD"
+  refresh-token:
+    secret-key: "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCD"
+    exptime: 1d
+  access-token:
+    exptime: 8h

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,11 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+
+jwt:
+  secret-key: "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCD"
+  refresh-token:
+    secret-key: "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCD"
+    exptime: 1d
+  access-token:
+    exptime: 8h

--- a/src/test/java/com/payper/server/JwtModulesOneFileTest.java
+++ b/src/test/java/com/payper/server/JwtModulesOneFileTest.java
@@ -1,0 +1,206 @@
+package com.payper.server;
+
+import com.payper.server.auth.jwt.RefreshTokenRepository;
+import com.payper.server.auth.jwt.entity.RefreshTokenEntity;
+import com.payper.server.auth.jwt.entity.JwtType;
+import com.payper.server.auth.jwt.exception.JwtValidAuthenticationException;
+import com.payper.server.auth.jwt.util.JwtParseUtil;
+import com.payper.server.auth.jwt.util.JwtProperties;
+import com.payper.server.auth.jwt.util.JwtRefreshTokenUtil;
+import com.payper.server.auth.jwt.util.JwtTokenUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class JwtModulesSpringBootIT {
+
+    @Autowired JwtProperties jwtProperties;
+
+    @Autowired JwtTokenUtil jwtTokenUtil;
+    @Autowired JwtParseUtil jwtParseUtil;
+
+    @Autowired JwtRefreshTokenUtil jwtRefreshTokenUtil;
+    @Autowired RefreshTokenRepository refreshTokenRepository;
+
+    /**
+     * ✅ 이 테스트는 "실제 MySQL 연동"이므로
+     *  - 각 테스트가 서로 간섭하지 않게 매번 DB를 비우고
+     *  - @Transactional이 적용된 테스트라면(기본 롤백)에도,
+     *    내부 util이 REQUIRES_NEW로 flush/commit을 때리며 남길 수 있어
+     *    BeforeEach에서 강제로 정리하는 방식이 안전함.
+     */
+    @BeforeEach
+    void cleanDb() {
+        refreshTokenRepository.deleteAll();
+        refreshTokenRepository.flush();
+    }
+
+    // ✅ JWT iat/exp는 라이브러리/표준 때문에 초 단위로 잘릴 수 있어 테스트도 초 단위로 비교
+    private static long epochSecond(Date d) {
+        return d.getTime() / 1000;
+    }
+
+    @Test
+    @DisplayName("ACCESS 토큰 발급 후 subject/iat/exp/type 파싱이 된다 (iat/exp는 초 단위 비교)")
+    void issueAndParse_accessToken() {
+        // given
+        String userIdentifier = "user-123";
+        Date now = new Date();
+        String accessToken = jwtTokenUtil.generateJwtToken(JwtType.ACCESS, now, userIdentifier);
+
+        // when
+        String sub = jwtParseUtil.getUserIdentifier(accessToken);
+        Date iat = jwtParseUtil.getIssuedAt(accessToken);
+        Date exp = jwtParseUtil.getExpiresAt(accessToken);
+        JwtType type = jwtParseUtil.getJwtType(accessToken);
+
+        // then
+        assertThat(sub).isEqualTo(userIdentifier);
+        assertThat(type).isEqualTo(JwtType.ACCESS);
+
+        assertThat(epochSecond(iat)).isEqualTo(epochSecond(now));
+
+        Date expectedExp = new Date(now.getTime() + jwtProperties.getAccessTokenTime());
+        assertThat(epochSecond(exp)).isEqualTo(epochSecond(expectedExp));
+    }
+
+    @Test
+    @DisplayName("REFRESH 토큰 발급 후 subject/iat/exp/type 파싱이 된다 (iat/exp는 초 단위 비교)")
+    void issueAndParse_refreshToken() {
+        // given
+        String userIdentifier = "user-999";
+        Date now = new Date();
+        String refreshToken = jwtTokenUtil.generateJwtToken(JwtType.REFRESH, now, userIdentifier);
+
+        // when
+        String sub = jwtParseUtil.getUserIdentifier(refreshToken);
+        Date iat = jwtParseUtil.getIssuedAt(refreshToken);
+        Date exp = jwtParseUtil.getExpiresAt(refreshToken);
+        JwtType type = jwtParseUtil.getJwtType(refreshToken);
+
+        // then
+        assertThat(sub).isEqualTo(userIdentifier);
+        assertThat(type).isEqualTo(JwtType.REFRESH);
+
+        assertThat(epochSecond(iat)).isEqualTo(epochSecond(now));
+
+        Date expectedExp = new Date(now.getTime() + jwtProperties.getRefreshTokenTime());
+        assertThat(epochSecond(exp)).isEqualTo(epochSecond(expectedExp));
+    }
+
+    @Test
+    @DisplayName("만료된 토큰은 JwtValidAuthenticationException이 발생한다")
+    void expiredToken_throws() {
+        // given: 1970 기준 발급 → 현재 시점에서 무조건 만료
+        String userIdentifier = "user-expired";
+        Date oldNow = new Date(0L);
+        String expired = jwtTokenUtil.generateJwtToken(JwtType.ACCESS, oldNow, userIdentifier);
+
+        // when & then
+        assertThatThrownBy(() -> jwtParseUtil.getUserIdentifier(expired))
+                .isInstanceOf(JwtValidAuthenticationException.class);
+    }
+
+    @Test
+    @DisplayName("토큰이 변조되면 JwtValidAuthenticationException이 발생한다 (SignatureException이 밖으로 새지 않음)")
+    void tamperedToken_throwsMappedException() {
+        // given
+        String userIdentifier = "user-tamper";
+        Date now = new Date();
+        String token = jwtTokenUtil.generateJwtToken(JwtType.ACCESS, now, userIdentifier);
+
+        // 마지막 문자 변조 → signature mismatch 유도
+        String tampered = token.substring(0, token.length() - 1)
+                + (token.endsWith("a") ? "b" : "a");
+
+        // then
+        assertThatThrownBy(() -> jwtParseUtil.getUserIdentifier(tampered))
+                .isInstanceOf(JwtValidAuthenticationException.class);
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더에서 Bearer 토큰을 추출한다")
+    void extractFromRequest_bearer() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer abc.def.ghi");
+
+        assertThat(jwtParseUtil.extractJwtTokenFromRequest(request))
+                .isEqualTo("abc.def.ghi");
+    }
+
+    /**
+     * ✅ DB 통합 플로우 테스트들은 '테스트 메서드 단위 트랜잭션' 안에서 실행되도록 @Transactional 부여
+     * - 이 테스트 클래스 전체에 @Transactional을 걸지 않는 이유:
+     *   util 내부에 REQUIRES_NEW가 섞여 있으면 테스트 트랜잭션 롤백으로도 데이터가 남을 수 있어서
+     *   오히려 오해를 만들기 쉬움.
+     * - 대신: 각 테스트 시작 전 cleanDb()로 완전 격리
+     */
+    @Test
+    @Transactional
+    @DisplayName("같은 raw refreshToken은 항상 같은 해시로 엔티티가 생성된다")
+    void refresh_sameToken_sameHash() {
+        String userIdentifier = "user-1";
+        String raw = "raw-refresh-token-value";
+
+        RefreshTokenEntity e1 = jwtRefreshTokenUtil.generateRefreshTokenEntity(userIdentifier, raw);
+        RefreshTokenEntity e2 = jwtRefreshTokenUtil.generateRefreshTokenEntity(userIdentifier, raw);
+
+        assertThat(e1.getUserIdentifier()).isEqualTo(userIdentifier);
+        assertThat(e1.getHashedRefreshToken()).isNotBlank();
+        assertThat(e1.getHashedRefreshToken()).isEqualTo(e2.getHashedRefreshToken());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("upsertRefreshTokenEntity는 (user 기준) 기존 토큰을 제거하고 새 토큰만 남긴다")
+    void refresh_upsert_replacesExistingTokenForUser() {
+        String userIdentifier = "user-upsert";
+
+        // 1) 첫 토큰 업서트
+        String raw1 = jwtTokenUtil.generateJwtToken(JwtType.REFRESH, new Date(), userIdentifier);
+        RefreshTokenEntity e1 = jwtRefreshTokenUtil.generateRefreshTokenEntity(userIdentifier, raw1);
+        jwtRefreshTokenUtil.upsertRefreshTokenEntity(e1);
+
+        assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw1)).isNotNull();
+
+        // 2) 두 번째 토큰 업서트 → 첫 토큰은 제거되어야 함
+        String raw2 = jwtTokenUtil.generateJwtToken(JwtType.REFRESH, new Date(), userIdentifier);
+        RefreshTokenEntity e2 = jwtRefreshTokenUtil.generateRefreshTokenEntity(userIdentifier, raw2);
+        jwtRefreshTokenUtil.upsertRefreshTokenEntity(e2);
+
+        assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw1)).isNull();
+
+        RefreshTokenEntity found2 = jwtRefreshTokenUtil.getRefreshTokenEntity(raw2);
+        assertThat(found2).isNotNull();
+        assertThat(found2.getUserIdentifier()).isEqualTo(userIdentifier);
+    }
+
+    @Test
+    //@Transactional
+    @DisplayName("deleteAllRefreshTokenEntity는 사용자 토큰을 삭제하고, 이후 조회가 null이 된다")
+    void refresh_deleteAll_deletesAndThenLookupNull() {
+        String userIdentifier = "user-del";
+
+        String raw = jwtTokenUtil.generateJwtToken(JwtType.REFRESH, new Date(), userIdentifier);
+        RefreshTokenEntity e = jwtRefreshTokenUtil.generateRefreshTokenEntity(userIdentifier, raw);
+        refreshTokenRepository.saveAndFlush(e);
+
+        assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw)).isNotNull();
+
+        int deleted = jwtRefreshTokenUtil.deleteAllRefreshTokenEntity(userIdentifier);
+
+        assertThat(deleted).isGreaterThanOrEqualTo(1);
+        assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw)).isNull();
+    }
+}

--- a/src/test/java/com/payper/server/JwtModulesSpringBootIntegrationTest.java
+++ b/src/test/java/com/payper/server/JwtModulesSpringBootIntegrationTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
 @ActiveProfiles("test")
-class JwtModulesSpringBootIT {
+class JwtModulesSpringBootIntegrationTest {
 
     @Autowired JwtProperties jwtProperties;
 
@@ -109,23 +109,6 @@ class JwtModulesSpringBootIT {
 
         // when & then
         assertThatThrownBy(() -> jwtParseUtil.getUserIdentifier(expired))
-                .isInstanceOf(JwtValidAuthenticationException.class);
-    }
-
-    @Test
-    @DisplayName("토큰이 변조되면 JwtValidAuthenticationException이 발생한다 (SignatureException이 밖으로 새지 않음)")
-    void tamperedToken_throwsMappedException() {
-        // given
-        String userIdentifier = "user-tamper";
-        Date now = new Date();
-        String token = jwtTokenUtil.generateJwtToken(JwtType.ACCESS, now, userIdentifier);
-
-        // 마지막 문자 변조 → signature mismatch 유도
-        String tampered = token.substring(0, token.length() - 1)
-                + (token.endsWith("a") ? "b" : "a");
-
-        // then
-        assertThatThrownBy(() -> jwtParseUtil.getUserIdentifier(tampered))
                 .isInstanceOf(JwtValidAuthenticationException.class);
     }
 

--- a/src/test/java/com/payper/server/JwtModulesSpringBootIntegrationTest.java
+++ b/src/test/java/com/payper/server/JwtModulesSpringBootIntegrationTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -25,20 +26,25 @@ import static org.assertj.core.api.Assertions.*;
 @ActiveProfiles("test")
 class JwtModulesSpringBootIntegrationTest {
 
-    @Autowired JwtProperties jwtProperties;
+    @Autowired
+    JwtProperties jwtProperties;
 
-    @Autowired JwtTokenUtil jwtTokenUtil;
-    @Autowired JwtParseUtil jwtParseUtil;
+    @Autowired
+    JwtTokenUtil jwtTokenUtil;
+    @Autowired
+    JwtParseUtil jwtParseUtil;
 
-    @Autowired JwtRefreshTokenUtil jwtRefreshTokenUtil;
-    @Autowired RefreshTokenRepository refreshTokenRepository;
+    @Autowired
+    JwtRefreshTokenUtil jwtRefreshTokenUtil;
+    @Autowired
+    RefreshTokenRepository refreshTokenRepository;
 
     /**
      * ✅ 이 테스트는 "실제 MySQL 연동"이므로
-     *  - 각 테스트가 서로 간섭하지 않게 매번 DB를 비우고
-     *  - @Transactional이 적용된 테스트라면(기본 롤백)에도,
-     *    내부 util이 REQUIRES_NEW로 flush/commit을 때리며 남길 수 있어
-     *    BeforeEach에서 강제로 정리하는 방식이 안전함.
+     * - 각 테스트가 서로 간섭하지 않게 매번 DB를 비우고
+     * - @Transactional이 적용된 테스트라면(기본 롤백)에도,
+     * 내부 util이 REQUIRES_NEW로 flush/commit을 때리며 남길 수 있어
+     * BeforeEach에서 강제로 정리하는 방식이 안전함.
      */
     @BeforeEach
     void cleanDb() {
@@ -125,8 +131,8 @@ class JwtModulesSpringBootIntegrationTest {
     /**
      * ✅ DB 통합 플로우 테스트들은 '테스트 메서드 단위 트랜잭션' 안에서 실행되도록 @Transactional 부여
      * - 이 테스트 클래스 전체에 @Transactional을 걸지 않는 이유:
-     *   util 내부에 REQUIRES_NEW가 섞여 있으면 테스트 트랜잭션 롤백으로도 데이터가 남을 수 있어서
-     *   오히려 오해를 만들기 쉬움.
+     * util 내부에 REQUIRES_NEW가 섞여 있으면 테스트 트랜잭션 롤백으로도 데이터가 남을 수 있어서
+     * 오히려 오해를 만들기 쉬움.
      * - 대신: 각 테스트 시작 전 cleanDb()로 완전 격리
      */
     @Test
@@ -155,18 +161,20 @@ class JwtModulesSpringBootIntegrationTest {
         RefreshTokenEntity e1 = jwtRefreshTokenUtil.generateRefreshTokenEntity(userIdentifier, raw1);
         jwtRefreshTokenUtil.upsertRefreshTokenEntity(e1);
 
-        assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw1)).isNotNull();
+        assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw1)).isNotEmpty();
 
         // 2) 두 번째 토큰 업서트 → 첫 토큰은 제거되어야 함
         String raw2 = jwtTokenUtil.generateJwtToken(JwtType.REFRESH, new Date(), userIdentifier);
         RefreshTokenEntity e2 = jwtRefreshTokenUtil.generateRefreshTokenEntity(userIdentifier, raw2);
         jwtRefreshTokenUtil.upsertRefreshTokenEntity(e2);
 
-        assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw1)).isNull();
+        assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw1)).isEmpty();
 
-        RefreshTokenEntity found2 = jwtRefreshTokenUtil.getRefreshTokenEntity(raw2);
+        Optional<RefreshTokenEntity> found2 = jwtRefreshTokenUtil.getRefreshTokenEntity(raw2);
         assertThat(found2).isNotNull();
-        assertThat(found2.getUserIdentifier()).isEqualTo(userIdentifier);
+        found2.ifPresent(
+                refreshTokenEntity -> assertThat(refreshTokenEntity.getUserIdentifier()
+                ).isEqualTo(userIdentifier));
     }
 
     @Test
@@ -179,11 +187,11 @@ class JwtModulesSpringBootIntegrationTest {
         RefreshTokenEntity e = jwtRefreshTokenUtil.generateRefreshTokenEntity(userIdentifier, raw);
         refreshTokenRepository.saveAndFlush(e);
 
-        assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw)).isNotNull();
+        assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw)).isNotEmpty();
 
         int deleted = jwtRefreshTokenUtil.deleteAllRefreshTokenEntity(userIdentifier);
 
         assertThat(deleted).isGreaterThanOrEqualTo(1);
-        assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw)).isNull();
+        assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw)).isEmpty();
     }
 }

--- a/src/test/java/com/payper/server/UserAndRefreshTokenJpaTest.java
+++ b/src/test/java/com/payper/server/UserAndRefreshTokenJpaTest.java
@@ -1,6 +1,6 @@
 package com.payper.server;
 
-import com.payper.server.auth.jwt.RefreshTokenEntity;
+import com.payper.server.auth.jwt.entity.RefreshTokenEntity;
 import com.payper.server.auth.jwt.RefreshTokenRepository;
 import com.payper.server.security.CustomUserDetails;
 import com.payper.server.user.UserRepository;


### PR DESCRIPTION
## 📌 개요
인증/인가에서 재사용할 JWT 유틸(Provider)을 독립적으로 완성한다.
REST 서버 + JWT에 맞는 최소 보안 설정을 먼저 고정한다.

## 🔧 작업 내용
JwtProvider 구현: access/refresh 생성
->
JwtTokenUtil, JwtRefreshTokenUtil, JwtParseUtil로 구현했습니다.
jwt토큰 생성, 리프레시 토큰 관련, 파싱 관련을 맡은 유틸들로 나눴습니다.

검증/파싱: 만료/서명/형식 오류 분류
-> 만료와 나머지로 나눴습니다.

클레임 규칙 확정: sub, roles, tokenType, iat, exp
-> JwtTokenUtil과 JwtParseUtil에서 확인하세요.

설정값 외부화: secret, issuer, 만료시간 등 (application.yml)
-> application.yml에 관련 키와 시간 추가했습니다.

세션 사용 안함: STATELESS
csrf 비활성화(순수 REST 기준)
formLogin/httpBasic 비활성화
authorizeHttpRequests로 permitAll 적용
CORS 설정(프론트 도메인/허용 헤더 Authorization/노출 헤더 등)
->설정완료

AuthenticationManager, PasswordEncoder 등 필요한 빈 정리(향후 확장 대비)
-> 추후에 넣겠습니다.

## ✅ 체크리스트
완료 조건 (DoD)

단위 테스트 또는 간단 테스트 코드로 발급/검증/만료 케이스 확인
-> 통합테스트로 확인

서버 기동 시 시큐리티 설정이 반영되고, permitAll 엔드포인트 접근 가능

## 📝 기타 참고 사항
- 주의할 점, 추후 리팩토링 필요성 등
- 해당 브랜치는 feat/#8 브랜치가 베이스입니다. 머지는 제가 할게요.

## 📎 관련 이슈
Close #9 
Close #10 