### PR TITLE
[FEATURE #11]: oauth 리소스 확보, 내부 jwt 발급, 사용자 crud

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/payper/server/auth/AuthController.java
+++ b/src/main/java/com/payper/server/auth/AuthController.java
@@ -3,16 +3,14 @@ package com.payper.server.auth;
 import com.payper.server.auth.dto.JoinRequest;
 import com.payper.server.auth.dto.LoginRequest;
 import com.payper.server.auth.dto.LoginSuccessResponse;
+import com.payper.server.auth.dto.ReissueSuccessResponse;
 import com.payper.server.global.response.ApiResponse;
 import com.payper.server.user.entity.AuthType;
 import com.payper.server.user.entity.User;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -46,8 +44,31 @@ public class AuthController {
         return issueTokensAndCreateResponse(user, response);
     }
 
-    private ResponseEntity<ApiResponse<LoginSuccessResponse>> issueTokensAndCreateResponse(User user, HttpServletResponse response) {
+    private ResponseEntity<ApiResponse<LoginSuccessResponse>>
+    issueTokensAndCreateResponse(User user, HttpServletResponse response) {
         String accessToken = authService.enrollNewAuthTokens(user, response);
         return ResponseEntity.ok(ApiResponse.ok(new LoginSuccessResponse(accessToken)));
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponse<ReissueSuccessResponse>> reissue(
+            @CookieValue(required = false) String refreshToken,
+            HttpServletResponse response
+    ){
+        String accessToken = authService.reissueAccessToken(refreshToken, response);
+
+        return ResponseEntity.ok(
+                ApiResponse.ok(new ReissueSuccessResponse(accessToken))
+        );
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<String>> logout(
+            @CookieValue(required = false) String refreshToken,
+            HttpServletResponse response
+    ) {
+        authService.clearRefreshTokenAndEntity(refreshToken, response);
+
+        return ResponseEntity.ok(ApiResponse.ok("logout success"));
     }
 }

--- a/src/main/java/com/payper/server/auth/AuthController.java
+++ b/src/main/java/com/payper/server/auth/AuthController.java
@@ -27,12 +27,8 @@ public class AuthController {
     ) {
         User user = authService.join(joinRequest);
 
-        String accessToken =
-                authService.enrollNewAuthTokens(user, response);
 
-        return ResponseEntity.ok(
-                ApiResponse.ok(new LoginSuccessResponse(accessToken))
-        );
+        return issueTokensAndCreateResponse(user, response);
     }
 
 
@@ -46,11 +42,12 @@ public class AuthController {
                 AuthType.KAKAO
         );
 
-        String accessToken =
-                authService.enrollNewAuthTokens(user, response);
 
-        return ResponseEntity.ok(
-                ApiResponse.ok(new LoginSuccessResponse(accessToken))
-        );
+        return issueTokensAndCreateResponse(user, response);
+    }
+
+    private ResponseEntity<ApiResponse<LoginSuccessResponse>> issueTokensAndCreateResponse(User user, HttpServletResponse response) {
+        String accessToken = authService.enrollNewAuthTokens(user, response);
+        return ResponseEntity.ok(ApiResponse.ok(new LoginSuccessResponse(accessToken)));
     }
 }

--- a/src/main/java/com/payper/server/auth/AuthController.java
+++ b/src/main/java/com/payper/server/auth/AuthController.java
@@ -4,13 +4,18 @@ import com.payper.server.auth.dto.JoinRequest;
 import com.payper.server.auth.dto.LoginRequest;
 import com.payper.server.auth.dto.LoginSuccessResponse;
 import com.payper.server.auth.dto.ReissueSuccessResponse;
+import com.payper.server.auth.util.OAuthUserInfo;
 import com.payper.server.global.response.ApiResponse;
+import com.payper.server.user.UserService;
 import com.payper.server.user.entity.AuthType;
 import com.payper.server.user.entity.User;
+import com.payper.server.user.entity.UserRole;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,43 +23,31 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
     private final AuthService authService;
 
-    @PostMapping("/join")
-    public ResponseEntity<ApiResponse<LoginSuccessResponse>> join(
-            @RequestBody JoinRequest joinRequest,
-            HttpServletResponse response
-    ) {
-        User user = authService.join(joinRequest);
-
-
-        return issueTokensAndCreateResponse(user, response);
-    }
-
-
-    @PostMapping("/login")
-    public ResponseEntity<ApiResponse<LoginSuccessResponse>> login(
+    @PostMapping("/login") //로그인 시도 -> 필요하면 가입 -> 로그인
+    public ResponseEntity<ApiResponse<LoginSuccessResponse>> enroll(
             @RequestBody LoginRequest loginRequest,
             HttpServletResponse response
     ) {
-        User user = authService.findUserWithOauthToken(
+        //OAuth 리소스 서버와 통신 문제 생기면 예외
+        OAuthUserInfo oauthUserInfo = authService.findOAuthUserInfo(
                 loginRequest.getOauthToken(),
                 AuthType.KAKAO
         );
 
+        //유저가 inactive(밴, 정지) 되어있으면 예외
+        User user = authService.findOrEnrollOAuthUser(oauthUserInfo);
 
-        return issueTokensAndCreateResponse(user, response);
-    }
-
-    private ResponseEntity<ApiResponse<LoginSuccessResponse>>
-    issueTokensAndCreateResponse(User user, HttpServletResponse response) {
         String accessToken = authService.enrollNewAuthTokens(user, response);
+
         return ResponseEntity.ok(ApiResponse.ok(new LoginSuccessResponse(accessToken)));
     }
+
 
     @PostMapping("/reissue")
     public ResponseEntity<ApiResponse<ReissueSuccessResponse>> reissue(
             @CookieValue(required = false) String refreshToken,
             HttpServletResponse response
-    ){
+    ) {
         String accessToken = authService.reissueAccessToken(refreshToken, response);
 
         return ResponseEntity.ok(

--- a/src/main/java/com/payper/server/auth/AuthController.java
+++ b/src/main/java/com/payper/server/auth/AuthController.java
@@ -1,0 +1,56 @@
+package com.payper.server.auth;
+
+import com.payper.server.auth.dto.JoinRequest;
+import com.payper.server.auth.dto.LoginRequest;
+import com.payper.server.auth.dto.LoginSuccessResponse;
+import com.payper.server.global.response.ApiResponse;
+import com.payper.server.user.entity.AuthType;
+import com.payper.server.user.entity.User;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/join")
+    public ResponseEntity<ApiResponse<LoginSuccessResponse>> join(
+            @RequestBody JoinRequest joinRequest,
+            HttpServletResponse response
+    ) {
+        User user = authService.join(joinRequest);
+
+        String accessToken =
+                authService.enrollNewAuthTokens(user, response);
+
+        return ResponseEntity.ok(
+                ApiResponse.ok(new LoginSuccessResponse(accessToken))
+        );
+    }
+
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginSuccessResponse>> login(
+            @RequestBody LoginRequest loginRequest,
+            HttpServletResponse response
+    ) {
+        User user = authService.findUserWithOauthToken(
+                loginRequest.getOauthToken(),
+                AuthType.KAKAO
+        );
+
+        String accessToken =
+                authService.enrollNewAuthTokens(user, response);
+
+        return ResponseEntity.ok(
+                ApiResponse.ok(new LoginSuccessResponse(accessToken))
+        );
+    }
+}

--- a/src/main/java/com/payper/server/auth/AuthGlobalExceptionHandler.java
+++ b/src/main/java/com/payper/server/auth/AuthGlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.payper.server.auth;
+
+import com.payper.server.auth.exception.OAuthException;
+import com.payper.server.auth.exception.UserAuthenticationException;
+import com.payper.server.auth.jwt.exception.ReissueException;
+import com.payper.server.global.response.ApiResponse;
+import com.payper.server.global.response.ErrorCode;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(
+        assignableTypes = {
+                AuthController.class,
+        }
+)
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class AuthGlobalExceptionHandler {
+
+    @ExceptionHandler(OAuthException.class)
+    public ResponseEntity<ApiResponse<Void>> handleOAuthException(final OAuthException exception) {
+        return buildErrorResponse(exception.getErrorCode());
+    }
+
+    @ExceptionHandler(UserAuthenticationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUserException(final UserAuthenticationException exception) {
+        return buildErrorResponse(exception.getErrorCode());
+    }
+
+    //AuthController 내에서 발생하는 JwtValidAuthentication 에러는 토큰 리이슈 관련 에러입니다.
+    @ExceptionHandler(ReissueException.class)
+    public ResponseEntity<ApiResponse<Void>> handleReissueException(
+            final ReissueException exception
+    ) {
+        return buildErrorResponse(exception.getErrorCode());
+    }
+
+
+    private ResponseEntity<ApiResponse<Void>> buildErrorResponse(ErrorCode errorCode) {
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode));
+    }
+}

--- a/src/main/java/com/payper/server/auth/AuthService.java
+++ b/src/main/java/com/payper/server/auth/AuthService.java
@@ -54,12 +54,8 @@ public class AuthService {
 
         OAuthUserInfo oauthUserInfo = switch (authType) {
             case AuthType.KAKAO -> kakaoOAuthUtil.getUserInfoFromOAuthToken(oauthToken);
-            default -> null;
+            default -> throw new OAuthException(ErrorCode.OAUTH_RESOURCE_ERROR);
         };
-
-        if (oauthUserInfo == null) {
-            throw new OAuthException(ErrorCode.OAUTH_RESOURCE_ERROR);
-        }
 
         return userService.getActiveOAuthUser(oauthUserInfo);
     }

--- a/src/main/java/com/payper/server/auth/AuthService.java
+++ b/src/main/java/com/payper/server/auth/AuthService.java
@@ -1,0 +1,83 @@
+package com.payper.server.auth;
+
+import com.payper.server.auth.dto.JoinRequest;
+import com.payper.server.auth.exception.OAuthException;
+import com.payper.server.auth.jwt.entity.JwtType;
+import com.payper.server.auth.jwt.entity.RefreshTokenEntity;
+import com.payper.server.auth.jwt.util.JwtParseUtil;
+import com.payper.server.auth.jwt.util.JwtRefreshTokenUtil;
+import com.payper.server.auth.jwt.util.JwtTokenUtil;
+import com.payper.server.auth.util.KakaoOAuthUtilImpl;
+import com.payper.server.auth.util.OAuthUserInfo;
+import com.payper.server.global.response.ErrorCode;
+import com.payper.server.user.UserService;
+import com.payper.server.user.entity.AuthType;
+import com.payper.server.user.entity.User;
+import com.payper.server.user.entity.UserRole;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+    private final UserService userService;
+    private final KakaoOAuthUtilImpl kakaoOAuthUtil;
+    private final JwtTokenUtil jwtTokenUtil;
+    private final JwtRefreshTokenUtil jwtRefreshTokenUtil;
+    private final JwtParseUtil jwtParseUtil;
+
+    public User join(JoinRequest joinRequest) {
+        String oauthToken = joinRequest.getOauthToken();
+        OAuthUserInfo oauthUserInfo = kakaoOAuthUtil.getUserInfoFromOAuthToken(oauthToken);
+
+        User user = User.create(
+                AuthType.KAKAO,
+                oauthUserInfo.getName(),
+                oauthUserInfo.getOauthId(),
+                UserRole.USER,
+                true
+        );
+
+        return userService.save(user);
+    }
+
+    public String enrollNewAuthTokens(User user, HttpServletResponse response) {
+        return upsertNewAuthTokens(user.getUserIdentifier(),response,new Date());
+    }
+
+    public User findUserWithOauthToken(String oauthToken, AuthType authType) {
+
+        OAuthUserInfo oauthUserInfo = switch (authType) {
+            case AuthType.KAKAO -> kakaoOAuthUtil.getUserInfoFromOAuthToken(oauthToken);
+            default -> null;
+        };
+
+        if (oauthUserInfo == null) {
+            throw new OAuthException(ErrorCode.OAUTH_RESOURCE_ERROR);
+        }
+
+        return userService.getActiveOAuthUser(oauthUserInfo);
+    }
+
+    private String upsertNewAuthTokens(String userIdentifier, HttpServletResponse response, Date issuedAt) {
+        String accessToken = jwtTokenUtil.generateJwtToken(JwtType.ACCESS, issuedAt, userIdentifier);
+        String refreshToken = jwtTokenUtil.generateJwtToken(JwtType.REFRESH, issuedAt, userIdentifier);
+
+        RefreshTokenEntity refreshTokenEntity =
+                jwtRefreshTokenUtil.generateRefreshTokenEntity(userIdentifier, refreshToken);
+
+
+        jwtRefreshTokenUtil.generateCookieRefreshToken(refreshToken, response);
+
+        jwtRefreshTokenUtil.upsertRefreshTokenEntity(refreshTokenEntity);
+
+        return accessToken;
+    }
+
+
+}

--- a/src/main/java/com/payper/server/auth/dto/JoinRequest.java
+++ b/src/main/java/com/payper/server/auth/dto/JoinRequest.java
@@ -1,10 +1,12 @@
 package com.payper.server.auth.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class JoinRequest {
+    @NotBlank(message="OAuth Provider가 제공한 oauth resource access token이 필요합니다.")
     private String oauthToken;
 }

--- a/src/main/java/com/payper/server/auth/dto/LoginRequest.java
+++ b/src/main/java/com/payper/server/auth/dto/LoginRequest.java
@@ -1,10 +1,13 @@
 package com.payper.server.auth.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class LoginRequest {
+
+    @NotBlank(message="OAuth Provider가 제공한 oauth resource access token이 필요합니다.")
     private String oauthToken;
 }

--- a/src/main/java/com/payper/server/auth/jwt/util/JwtRefreshTokenUtil.java
+++ b/src/main/java/com/payper/server/auth/jwt/util/JwtRefreshTokenUtil.java
@@ -2,6 +2,8 @@ package com.payper.server.auth.jwt.util;
 
 import com.payper.server.auth.jwt.RefreshTokenRepository;
 import com.payper.server.auth.jwt.entity.RefreshTokenEntity;
+import com.payper.server.auth.jwt.exception.ReissueException;
+import com.payper.server.global.response.ErrorCode;
 import io.jsonwebtoken.Jwts;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.Cookie;
@@ -18,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.Base64;
 import java.util.Date;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -70,10 +73,9 @@ public class JwtRefreshTokenUtil {
         return count;
     }
 
-    public RefreshTokenEntity getRefreshTokenEntity(String refreshToken) {
+    public Optional<RefreshTokenEntity> getRefreshTokenEntity(String refreshToken) {
         return refreshTokenRepository
-                .findByHashedRefreshToken(hashRefreshToken(refreshToken))
-                .orElse(null);
+                .findByHashedRefreshToken(hashRefreshToken(refreshToken));
     }
 
 

--- a/src/main/java/com/payper/server/auth/util/KakaoOAuthUtilImpl.java
+++ b/src/main/java/com/payper/server/auth/util/KakaoOAuthUtilImpl.java
@@ -1,0 +1,65 @@
+package com.payper.server.auth.util;
+
+import com.payper.server.auth.exception.OAuthException;
+import com.payper.server.global.response.ErrorCode;
+import com.payper.server.user.entity.AuthType;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthUtilImpl implements OAuthUtil {
+    private static final String PROPERTY_KEYS = "[\"kakao_account.profile\"]";
+
+    private RestClient kakaoRestClient;
+    private final ObjectMapper objectMapper;
+
+    @PostConstruct
+    protected void init() {
+        kakaoRestClient=RestClient.builder()
+                .baseUrl("https://kapi.kakao.com")
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+
+    @Override
+    public OAuthUserInfo getUserInfoFromOAuthToken(String oAuthToken) {
+        String body = kakaoRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/v2/user/me")
+                        .queryParam("property_keys", PROPERTY_KEYS)
+                        .build())
+                .headers(headers -> headers.setBearerAuth(oAuthToken))
+                .retrieve()
+                .onStatus(
+                        HttpStatusCode::isError,
+                        (request, response) ->
+                        {
+                            throw new OAuthException(ErrorCode.OAUTH_RESOURCE_ERROR);
+                        }
+                )
+                .body(String.class);
+
+        try {
+            JsonNode json = objectMapper.readTree(body);
+
+            String name = json.path("kakao_account")
+                    .path("profile")
+                    .path("nickname")
+                    .asString();
+
+            String kakaoId = json.path("id").asString();
+
+            return new OAuthUserInfo(name, kakaoId, AuthType.KAKAO);
+        } catch (Exception e) {
+            throw new OAuthException(ErrorCode.OAUTH_RESOURCE_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/payper/server/auth/util/OAuthUserInfo.java
+++ b/src/main/java/com/payper/server/auth/util/OAuthUserInfo.java
@@ -1,0 +1,16 @@
+package com.payper.server.auth.util;
+
+import com.payper.server.user.entity.AuthType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Getter
+@AllArgsConstructor
+public class OAuthUserInfo {
+    private String name;
+
+    private String oauthId;
+
+    private AuthType authType;
+}

--- a/src/main/java/com/payper/server/auth/util/OAuthUserInfo.java
+++ b/src/main/java/com/payper/server/auth/util/OAuthUserInfo.java
@@ -3,7 +3,6 @@ package com.payper.server.auth.util;
 import com.payper.server.user.entity.AuthType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.beans.factory.annotation.Autowired;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/payper/server/auth/util/OAuthUtil.java
+++ b/src/main/java/com/payper/server/auth/util/OAuthUtil.java
@@ -1,0 +1,5 @@
+package com.payper.server.auth.util;
+
+public interface OAuthUtil {
+    OAuthUserInfo getUserInfoFromOAuthToken(String oAuthToken);
+}

--- a/src/main/java/com/payper/server/domain/test/TestAuthController.java
+++ b/src/main/java/com/payper/server/domain/test/TestAuthController.java
@@ -1,0 +1,34 @@
+package com.payper.server.domain.test;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RestController
+public class TestAuthController {
+    @GetMapping("/")
+    public String index() {
+        return "Hello World";
+    }
+
+    @GetMapping("/me")
+    public String getMe(
+            Principal principal,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        System.out.println("principal.getName() = " + principal.getName());
+        System.out.println("userDetails.username() = " + userDetails.getUsername());
+        System.out.println("userDetails.password() = " + userDetails.getPassword());
+        System.out.println("userDetails.getAuthorities() = " + userDetails.getAuthorities());
+
+        return "Hello me";
+    }
+
+    @GetMapping("/admin")
+    public String admin() {
+        return "Hello Admin";
+    }
+}

--- a/src/main/java/com/payper/server/domain/test/TestController.java
+++ b/src/main/java/com/payper/server/domain/test/TestController.java
@@ -4,9 +4,13 @@ import com.payper.server.global.exception.ApiException;
 import com.payper.server.global.response.ApiResponse;
 import com.payper.server.global.response.ErrorCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
 
 @RestController
 @RequestMapping("/test")
@@ -30,4 +34,6 @@ public class TestController {
     public ResponseEntity<ApiResponse<Void>> testFailure3() throws Exception {
         throw new Exception();
     }
+
+
 }

--- a/src/main/java/com/payper/server/global/response/ErrorCode.java
+++ b/src/main/java/com/payper/server/global/response/ErrorCode.java
@@ -26,6 +26,8 @@ public enum ErrorCode {
     UNAUTHORIZED("SEC-002", HttpStatus.FORBIDDEN, "Unauthorized"),
     USER_DUPLICATE("SEC-003", HttpStatus.INTERNAL_SERVER_ERROR, "Duplicate User"),
     USER_NOTFOUND("SEC-004", HttpStatus.INTERNAL_SERVER_ERROR, "User Not Exists"),
+    USER_INACTIVE("SEC-005", HttpStatus.INTERNAL_SERVER_ERROR, "User Inactive"),
+
     OAUTH_RESOURCE_ERROR("OAUTH-001", HttpStatus.SERVICE_UNAVAILABLE, "OAuth Resource Unavailable");
 
 

--- a/src/main/java/com/payper/server/global/response/ErrorCode.java
+++ b/src/main/java/com/payper/server/global/response/ErrorCode.java
@@ -19,7 +19,8 @@ public enum ErrorCode {
     JWT_EXPIRED("JWT_002", HttpStatus.UNAUTHORIZED, "JWT Expired"),
     JWT_REISSUE_ERROR("JWT_003", HttpStatus.INTERNAL_SERVER_ERROR, "Refresh Token General Error"),
     JWT_REISSUE_EXPIRED("JWT_004", HttpStatus.INTERNAL_SERVER_ERROR, "Refresh Token Expired"),
-    REISSUE_ERROR("JWT_005", HttpStatus.INTERNAL_SERVER_ERROR, "Reissue General Error"),
+    JWT_REISSUE_OLD("JWT_005", HttpStatus.INTERNAL_SERVER_ERROR, "Refresh Token Is Old"),
+    REISSUE_ERROR("JWT_006", HttpStatus.INTERNAL_SERVER_ERROR, "Reissue General Error"),
 
     //AUTHENTICATION - GENERAL
     UNAUTHENTICATED("SEC-001", HttpStatus.UNAUTHORIZED, "Unauthenticated"),

--- a/src/main/java/com/payper/server/global/response/ErrorCode.java
+++ b/src/main/java/com/payper/server/global/response/ErrorCode.java
@@ -27,7 +27,7 @@ public enum ErrorCode {
     UNAUTHORIZED("SEC-002", HttpStatus.FORBIDDEN, "Unauthorized"),
     USER_DUPLICATE("SEC-003", HttpStatus.INTERNAL_SERVER_ERROR, "Duplicate User"),
     USER_NOTFOUND("SEC-004", HttpStatus.INTERNAL_SERVER_ERROR, "User Not Exists"),
-    USER_INACTIVE("SEC-005", HttpStatus.INTERNAL_SERVER_ERROR, "User Inactive"),
+    USER_INACTIVE("SEC-005", HttpStatus.INTERNAL_SERVER_ERROR, "User Banned"),
 
     OAUTH_RESOURCE_ERROR("OAUTH-001", HttpStatus.SERVICE_UNAVAILABLE, "OAuth Resource Unavailable");
 

--- a/src/main/java/com/payper/server/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/payper/server/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,49 @@
+package com.payper.server.security;
+
+import com.payper.server.global.response.ApiResponse;
+import com.payper.server.global.response.ErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException, ServletException {
+
+        ApiResponse<String> failResponseDto;
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if(authentication==null||!(authentication.isAuthenticated())) {
+            failResponseDto =
+                    ApiResponse.fail(ErrorCode.UNAUTHENTICATED, accessDeniedException.getMessage());
+        }
+        else{
+            failResponseDto =
+                    ApiResponse.fail(ErrorCode.UNAUTHORIZED, accessDeniedException.getMessage());
+        }
+
+        response.setStatus(failResponseDto.getStatus());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        objectMapper.writeValue(response.getWriter(), failResponseDto);
+    }
+}

--- a/src/main/java/com/payper/server/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/payper/server/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,68 @@
+package com.payper.server.security;
+
+import com.payper.server.auth.exception.UserAuthenticationException;
+import com.payper.server.auth.jwt.exception.JwtValidAuthenticationException;
+import com.payper.server.global.response.ApiResponse;
+import com.payper.server.global.response.ErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@RequiredArgsConstructor
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException, ServletException {
+
+        if (response.isCommitted()) {
+            return;
+        }
+
+        ErrorCode errorCode = resolveErrorCode(request, authException);
+
+        ApiResponse<Void> body = ApiResponse.fail(errorCode);
+
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        objectMapper.writeValue(response.getWriter(), body);
+    }
+
+    private ErrorCode resolveErrorCode(HttpServletRequest request, AuthenticationException ex) {
+
+        // 1) 내가 만든 커스텀 예외면 그대로 사용
+        if (ex instanceof JwtValidAuthenticationException jwtEx) {
+            return jwtEx.getErrorCode();
+        }
+        if(ex instanceof  UserAuthenticationException userEx) {
+            return userEx.getErrorCode();
+        }
+
+        // 3) 토큰이 아예 없거나(익명 접근) 등으로 발생하는 대표 케이스
+        if (ex instanceof InsufficientAuthenticationException) {
+            return ErrorCode.UNAUTHENTICATED;
+        }
+
+        // 4) 최후의 기본값
+        return ErrorCode.UNAUTHENTICATED;
+    }
+
+}

--- a/src/main/java/com/payper/server/security/CustomUserDetailsService.java
+++ b/src/main/java/com/payper/server/security/CustomUserDetailsService.java
@@ -1,0 +1,35 @@
+package com.payper.server.security;
+
+import com.payper.server.auth.exception.UserAuthenticationException;
+import com.payper.server.global.response.ErrorCode;
+import com.payper.server.user.UserRepository;
+import com.payper.server.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String userIdentifier) throws UsernameNotFoundException {
+        User activeUser = getActiveUserByUserIdentifier(userIdentifier);
+        return new CustomUserDetails(activeUser);
+    }
+
+    public User getActiveUserByUserIdentifier(String userIdentifier) {
+        User user = userRepository.findByUserIdentifier(userIdentifier)
+                .orElseThrow(() -> new UserAuthenticationException(ErrorCode.USER_NOTFOUND));
+
+        if (!user.isActive()) {
+            throw new UserAuthenticationException(ErrorCode.USER_NOTFOUND);
+        }
+        return user;
+    }
+}

--- a/src/main/java/com/payper/server/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/payper/server/security/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package com.payper.server.security;
+
+import com.payper.server.auth.jwt.util.JwtParseUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final RequestMatcher skipRequestMatcher;
+    private final JwtParseUtil jwtParseUtil;
+    private final AuthenticationManager authenticationManager;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return skipRequestMatcher.matches(request);
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        //System.out.println("JwtAuthenticationFilter.doFilterInternal");
+
+        String accessToken = jwtParseUtil.extractJwtTokenFromRequest(request);
+
+        if (accessToken == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try{
+            Authentication requestAuth =
+                    UsernamePasswordAuthenticationToken.unauthenticated(null, accessToken);
+
+            Authentication authenticated =
+                    authenticationManager.authenticate(requestAuth);
+            SecurityContextHolder.getContext().setAuthentication(authenticated);
+            filterChain.doFilter(request, response);
+        }
+        catch(AuthenticationException e){
+            SecurityContextHolder.clearContext();
+            customAuthenticationEntryPoint.commence(request, response, e);
+        }
+    }
+}

--- a/src/main/java/com/payper/server/security/JwtAuthenticationProvider.java
+++ b/src/main/java/com/payper/server/security/JwtAuthenticationProvider.java
@@ -1,0 +1,42 @@
+package com.payper.server.security;
+
+import com.payper.server.auth.jwt.entity.JwtType;
+import com.payper.server.auth.jwt.exception.JwtValidAuthenticationException;
+import com.payper.server.auth.jwt.util.JwtParseUtil;
+import com.payper.server.global.response.ErrorCode;
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+    private final UserDetailsService userDetailsService;
+    private final JwtParseUtil jwtParseUtil;
+
+    @Override
+    public @Nullable Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        String accessToken = (String) authentication.getCredentials();
+
+        if (jwtParseUtil.getJwtType(accessToken) != JwtType.ACCESS) {
+            throw new JwtValidAuthenticationException(ErrorCode.JWT_ERROR);
+        }
+
+        String userIdentifier = jwtParseUtil.getUserIdentifier(accessToken);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(userIdentifier);
+
+        return UsernamePasswordAuthenticationToken.authenticated(userDetails, null, userDetails.getAuthorities());
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}
+

--- a/src/main/java/com/payper/server/security/SecurityConfig.java
+++ b/src/main/java/com/payper/server/security/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
                 PathPatternRequestMatcher.withDefaults().basePath("/");
 
         permitAllRequestMatcher = new OrRequestMatcher(
+                //requestMatcher.matcher("/**"),//<-테스트할 때는 이 내용 넣어주세요.
                 requestMatcher.matcher(HttpMethod.GET, "/swagger-ui/**"),
                 requestMatcher.matcher(HttpMethod.GET, "/v3/api-docs/**"),
                 requestMatcher.matcher(HttpMethod.GET, "/favicon.ico"),

--- a/src/main/java/com/payper/server/user/UserRepository.java
+++ b/src/main/java/com/payper/server/user/UserRepository.java
@@ -18,5 +18,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByOauthIdAndActive(String oauthId, boolean active);
 
-    Optional<User> findByOauthIdAndNameAndAuthType(String oauthId, String name, AuthType authType);
+    Optional<User> findByOauthIdAndAuthType(String oauthId, AuthType authType);
 }

--- a/src/main/java/com/payper/server/user/UserService.java
+++ b/src/main/java/com/payper/server/user/UserService.java
@@ -1,0 +1,53 @@
+package com.payper.server.user;
+
+import com.payper.server.auth.exception.UserAuthenticationException;
+import com.payper.server.auth.util.OAuthUserInfo;
+import com.payper.server.global.response.ErrorCode;
+import com.payper.server.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserService {
+    private final UserRepository userRepository;
+
+    public User save(final User user) {
+        validateDuplicate(user);
+
+        return userRepository.save(user);
+    }
+
+    private void validateDuplicate(final User user) {
+        Optional<User> findUser = switch (user.getAuthType()) {
+            case KAKAO -> userRepository.findByOauthIdAndActive(user.getOauthId(), true);
+            default -> Optional.empty();
+        };
+
+        if (findUser.isPresent()) {
+            throw new UserAuthenticationException(ErrorCode.USER_DUPLICATE);
+        }
+    }
+
+    public User getActiveOAuthUser(OAuthUserInfo oAuthUserInfo) {
+        User user =
+                userRepository.findByOauthIdAndAuthType(
+                                oAuthUserInfo.getOauthId(),
+                                oAuthUserInfo.getAuthType()
+                        )
+                        .orElseThrow(() -> new UserAuthenticationException(ErrorCode.USER_NOTFOUND));
+
+        if (!user.isActive()) {
+            throw new UserAuthenticationException(ErrorCode.USER_NOTFOUND);
+        }
+        return user;
+    }
+
+    public void delete(final User user) {
+        userRepository.updateActiveById(false, user.getId());
+    }
+}

--- a/src/main/java/com/payper/server/user/UserService.java
+++ b/src/main/java/com/payper/server/user/UserService.java
@@ -25,7 +25,8 @@ public class UserService {
     private void validateDuplicate(final User user) {
         Optional<User> findUser = switch (user.getAuthType()) {
             case KAKAO -> userRepository.findByOauthIdAndActive(user.getOauthId(), true);
-            default -> Optional.empty();
+            default ->
+                    throw new IllegalArgumentException("Unsupported AuthType for duplicate validation: " + user.getAuthType());
         };
 
         if (findUser.isPresent()) {
@@ -42,7 +43,7 @@ public class UserService {
                         .orElseThrow(() -> new UserAuthenticationException(ErrorCode.USER_NOTFOUND));
 
         if (!user.isActive()) {
-            throw new UserAuthenticationException(ErrorCode.USER_NOTFOUND);
+            throw new UserAuthenticationException(ErrorCode.USER_INACTIVE);
         }
         return user;
     }

--- a/src/main/java/com/payper/server/user/UserService.java
+++ b/src/main/java/com/payper/server/user/UserService.java
@@ -17,8 +17,6 @@ public class UserService {
     private final UserRepository userRepository;
 
     public User save(final User user) {
-        validateDuplicate(user);
-
         return userRepository.save(user);
     }
 
@@ -34,17 +32,21 @@ public class UserService {
         }
     }
 
-    public User getActiveOAuthUser(OAuthUserInfo oAuthUserInfo) {
-        User user =
+    public Optional<User> getActiveOAuthUser(OAuthUserInfo oAuthUserInfo) {
+        Optional<User> user =
                 userRepository.findByOauthIdAndAuthType(
-                                oAuthUserInfo.getOauthId(),
-                                oAuthUserInfo.getAuthType()
-                        )
-                        .orElseThrow(() -> new UserAuthenticationException(ErrorCode.USER_NOTFOUND));
+                        oAuthUserInfo.getOauthId(),
+                        oAuthUserInfo.getAuthType()
+                );
 
-        if (!user.isActive()) {
-            throw new UserAuthenticationException(ErrorCode.USER_INACTIVE);
-        }
+        user.ifPresent(
+                u -> {
+                    if (!u.isActive()) {
+                        throw new UserAuthenticationException(ErrorCode.USER_INACTIVE);
+                    }
+                }
+        );
+
         return user;
     }
 

--- a/src/test/java/com/payper/server/JwtModulesSpringBootIntegrationTest.java
+++ b/src/test/java/com/payper/server/JwtModulesSpringBootIntegrationTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -25,20 +26,25 @@ import static org.assertj.core.api.Assertions.*;
 @ActiveProfiles("test")
 class JwtModulesSpringBootIntegrationTest {
 
-    @Autowired JwtProperties jwtProperties;
+    @Autowired
+    JwtProperties jwtProperties;
 
-    @Autowired JwtTokenUtil jwtTokenUtil;
-    @Autowired JwtParseUtil jwtParseUtil;
+    @Autowired
+    JwtTokenUtil jwtTokenUtil;
+    @Autowired
+    JwtParseUtil jwtParseUtil;
 
-    @Autowired JwtRefreshTokenUtil jwtRefreshTokenUtil;
-    @Autowired RefreshTokenRepository refreshTokenRepository;
+    @Autowired
+    JwtRefreshTokenUtil jwtRefreshTokenUtil;
+    @Autowired
+    RefreshTokenRepository refreshTokenRepository;
 
     /**
      * ✅ 이 테스트는 "실제 MySQL 연동"이므로
-     *  - 각 테스트가 서로 간섭하지 않게 매번 DB를 비우고
-     *  - @Transactional이 적용된 테스트라면(기본 롤백)에도,
-     *    내부 util이 REQUIRES_NEW로 flush/commit을 때리며 남길 수 있어
-     *    BeforeEach에서 강제로 정리하는 방식이 안전함.
+     * - 각 테스트가 서로 간섭하지 않게 매번 DB를 비우고
+     * - @Transactional이 적용된 테스트라면(기본 롤백)에도,
+     * 내부 util이 REQUIRES_NEW로 flush/commit을 때리며 남길 수 있어
+     * BeforeEach에서 강제로 정리하는 방식이 안전함.
      */
     @BeforeEach
     void cleanDb() {
@@ -125,8 +131,8 @@ class JwtModulesSpringBootIntegrationTest {
     /**
      * ✅ DB 통합 플로우 테스트들은 '테스트 메서드 단위 트랜잭션' 안에서 실행되도록 @Transactional 부여
      * - 이 테스트 클래스 전체에 @Transactional을 걸지 않는 이유:
-     *   util 내부에 REQUIRES_NEW가 섞여 있으면 테스트 트랜잭션 롤백으로도 데이터가 남을 수 있어서
-     *   오히려 오해를 만들기 쉬움.
+     * util 내부에 REQUIRES_NEW가 섞여 있으면 테스트 트랜잭션 롤백으로도 데이터가 남을 수 있어서
+     * 오히려 오해를 만들기 쉬움.
      * - 대신: 각 테스트 시작 전 cleanDb()로 완전 격리
      */
     @Test
@@ -164,9 +170,11 @@ class JwtModulesSpringBootIntegrationTest {
 
         assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw1)).isNull();
 
-        RefreshTokenEntity found2 = jwtRefreshTokenUtil.getRefreshTokenEntity(raw2);
+        Optional<RefreshTokenEntity> found2 = jwtRefreshTokenUtil.getRefreshTokenEntity(raw2);
         assertThat(found2).isNotNull();
-        assertThat(found2.getUserIdentifier()).isEqualTo(userIdentifier);
+        found2.ifPresent(
+                refreshTokenEntity -> assertThat(refreshTokenEntity.getUserIdentifier()
+                ).isEqualTo(userIdentifier));
     }
 
     @Test

--- a/src/test/java/com/payper/server/JwtModulesSpringBootIntegrationTest.java
+++ b/src/test/java/com/payper/server/JwtModulesSpringBootIntegrationTest.java
@@ -161,14 +161,14 @@ class JwtModulesSpringBootIntegrationTest {
         RefreshTokenEntity e1 = jwtRefreshTokenUtil.generateRefreshTokenEntity(userIdentifier, raw1);
         jwtRefreshTokenUtil.upsertRefreshTokenEntity(e1);
 
-        assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw1)).isNotNull();
+        assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw1)).isNotEmpty();
 
         // 2) 두 번째 토큰 업서트 → 첫 토큰은 제거되어야 함
         String raw2 = jwtTokenUtil.generateJwtToken(JwtType.REFRESH, new Date(), userIdentifier);
         RefreshTokenEntity e2 = jwtRefreshTokenUtil.generateRefreshTokenEntity(userIdentifier, raw2);
         jwtRefreshTokenUtil.upsertRefreshTokenEntity(e2);
 
-        assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw1)).isNull();
+        assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw1)).isEmpty();
 
         Optional<RefreshTokenEntity> found2 = jwtRefreshTokenUtil.getRefreshTokenEntity(raw2);
         assertThat(found2).isNotNull();
@@ -187,11 +187,11 @@ class JwtModulesSpringBootIntegrationTest {
         RefreshTokenEntity e = jwtRefreshTokenUtil.generateRefreshTokenEntity(userIdentifier, raw);
         refreshTokenRepository.saveAndFlush(e);
 
-        assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw)).isNotNull();
+        assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw)).isNotEmpty();
 
         int deleted = jwtRefreshTokenUtil.deleteAllRefreshTokenEntity(userIdentifier);
 
         assertThat(deleted).isGreaterThanOrEqualTo(1);
-        assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw)).isNull();
+        assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw)).isEmpty();
     }
 }


### PR DESCRIPTION
## 📌 개요
프론트에서 받은 code 또는 외부 accessToken으로 사용자 정보를 확보하고, 내부 JWT를 발급한다.

## 🔧 작업 내용
“코드→토큰교환” 또는 “외부 토큰→유저정보조회” 구현(프로젝트 요구에 맞게)
-> KakaoOauthUtil 구현했습니다.

사용자 프로비저닝(신규 생성/기존 업데이트)
-> UserService 구현했습니다.

내부 accessToken 발급 + 응답 DTO로 반환
-> AuthService 구현햇습니다.

refreshToken 생성 후 DB 저장
-> AuthService에 구현했습니다.

## ✅ 체크리스트

완료 조건 (DoD)

/auth/join 또는 /auth/login 호출 시 accessToken이 응답되고 refreshToken이 DB에 저장됨
-> 확인했습니다.

## 📝 기타 참고 사항
- 주의할 점, 추후 리팩토링 필요성 등
해당 브랜치의 베이스는 feat/#9입니다.

## 📎 관련 이슈
Close #11