### PR TITLE
[FEATURE #12]: CustomUserDetailsService 구현 + JWT 인증 필터 구현, 인가(Authorization) 정책 적용 (ROLE 기반)

### DIFF
--- a/src/main/java/com/payper/server/auth/AuthController.java
+++ b/src/main/java/com/payper/server/auth/AuthController.java
@@ -3,16 +3,14 @@ package com.payper.server.auth;
 import com.payper.server.auth.dto.JoinRequest;
 import com.payper.server.auth.dto.LoginRequest;
 import com.payper.server.auth.dto.LoginSuccessResponse;
+import com.payper.server.auth.dto.ReissueSuccessResponse;
 import com.payper.server.global.response.ApiResponse;
 import com.payper.server.user.entity.AuthType;
 import com.payper.server.user.entity.User;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -46,8 +44,31 @@ public class AuthController {
         return issueTokensAndCreateResponse(user, response);
     }
 
-    private ResponseEntity<ApiResponse<LoginSuccessResponse>> issueTokensAndCreateResponse(User user, HttpServletResponse response) {
+    private ResponseEntity<ApiResponse<LoginSuccessResponse>>
+    issueTokensAndCreateResponse(User user, HttpServletResponse response) {
         String accessToken = authService.enrollNewAuthTokens(user, response);
         return ResponseEntity.ok(ApiResponse.ok(new LoginSuccessResponse(accessToken)));
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponse<ReissueSuccessResponse>> reissue(
+            @CookieValue(required = false) String refreshToken,
+            HttpServletResponse response
+    ){
+        String accessToken = authService.reissueAccessToken(refreshToken, response);
+
+        return ResponseEntity.ok(
+                ApiResponse.ok(new ReissueSuccessResponse(accessToken))
+        );
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<String>> logout(
+            @CookieValue(required = false) String refreshToken,
+            HttpServletResponse response
+    ) {
+        authService.clearRefreshTokenAndEntity(refreshToken, response);
+
+        return ResponseEntity.ok(ApiResponse.ok("logout success"));
     }
 }

--- a/src/main/java/com/payper/server/auth/AuthGlobalExceptionHandler.java
+++ b/src/main/java/com/payper/server/auth/AuthGlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.payper.server.auth;
+
+import com.payper.server.auth.exception.OAuthException;
+import com.payper.server.auth.exception.UserAuthenticationException;
+import com.payper.server.auth.jwt.exception.ReissueException;
+import com.payper.server.global.response.ApiResponse;
+import com.payper.server.global.response.ErrorCode;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(
+        assignableTypes = {
+                AuthController.class,
+        }
+)
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class AuthGlobalExceptionHandler {
+
+    @ExceptionHandler(OAuthException.class)
+    public ResponseEntity<ApiResponse<Void>> handleOAuthException(final OAuthException exception) {
+        return buildErrorResponse(exception.getErrorCode());
+    }
+
+    @ExceptionHandler(UserAuthenticationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUserException(final UserAuthenticationException exception) {
+        return buildErrorResponse(exception.getErrorCode());
+    }
+
+    //AuthController 내에서 발생하는 JwtValidAuthentication 에러는 토큰 리이슈 관련 에러입니다.
+    @ExceptionHandler(ReissueException.class)
+    public ResponseEntity<ApiResponse<Void>> handleReissueException(
+            final ReissueException exception
+    ) {
+        return buildErrorResponse(exception.getErrorCode());
+    }
+
+
+    private ResponseEntity<ApiResponse<Void>> buildErrorResponse(ErrorCode errorCode) {
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode));
+    }
+}

--- a/src/main/java/com/payper/server/auth/jwt/util/JwtRefreshTokenUtil.java
+++ b/src/main/java/com/payper/server/auth/jwt/util/JwtRefreshTokenUtil.java
@@ -2,6 +2,8 @@ package com.payper.server.auth.jwt.util;
 
 import com.payper.server.auth.jwt.RefreshTokenRepository;
 import com.payper.server.auth.jwt.entity.RefreshTokenEntity;
+import com.payper.server.auth.jwt.exception.ReissueException;
+import com.payper.server.global.response.ErrorCode;
 import io.jsonwebtoken.Jwts;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.Cookie;
@@ -18,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.Base64;
 import java.util.Date;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -70,10 +73,9 @@ public class JwtRefreshTokenUtil {
         return count;
     }
 
-    public RefreshTokenEntity getRefreshTokenEntity(String refreshToken) {
+    public Optional<RefreshTokenEntity> getRefreshTokenEntity(String refreshToken) {
         return refreshTokenRepository
-                .findByHashedRefreshToken(hashRefreshToken(refreshToken))
-                .orElse(null);
+                .findByHashedRefreshToken(hashRefreshToken(refreshToken));
     }
 
 

--- a/src/main/java/com/payper/server/domain/test/TestAuthController.java
+++ b/src/main/java/com/payper/server/domain/test/TestAuthController.java
@@ -1,0 +1,34 @@
+package com.payper.server.domain.test;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RestController
+public class TestAuthController {
+    @GetMapping("/")
+    public String index() {
+        return "Hello World";
+    }
+
+    @GetMapping("/me")
+    public String getMe(
+            Principal principal,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        System.out.println("principal.getName() = " + principal.getName());
+        System.out.println("userDetails.username() = " + userDetails.getUsername());
+        System.out.println("userDetails.password() = " + userDetails.getPassword());
+        System.out.println("userDetails.getAuthorities() = " + userDetails.getAuthorities());
+
+        return "Hello me";
+    }
+
+    @GetMapping("/admin")
+    public String admin() {
+        return "Hello Admin";
+    }
+}

--- a/src/main/java/com/payper/server/domain/test/TestController.java
+++ b/src/main/java/com/payper/server/domain/test/TestController.java
@@ -4,9 +4,13 @@ import com.payper.server.global.exception.ApiException;
 import com.payper.server.global.response.ApiResponse;
 import com.payper.server.global.response.ErrorCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
 
 @RestController
 @RequestMapping("/test")
@@ -30,4 +34,6 @@ public class TestController {
     public ResponseEntity<ApiResponse<Void>> testFailure3() throws Exception {
         throw new Exception();
     }
+
+
 }

--- a/src/main/java/com/payper/server/global/response/ErrorCode.java
+++ b/src/main/java/com/payper/server/global/response/ErrorCode.java
@@ -19,7 +19,8 @@ public enum ErrorCode {
     JWT_EXPIRED("JWT_002", HttpStatus.UNAUTHORIZED, "JWT Expired"),
     JWT_REISSUE_ERROR("JWT_003", HttpStatus.INTERNAL_SERVER_ERROR, "Refresh Token General Error"),
     JWT_REISSUE_EXPIRED("JWT_004", HttpStatus.INTERNAL_SERVER_ERROR, "Refresh Token Expired"),
-    REISSUE_ERROR("JWT_005", HttpStatus.INTERNAL_SERVER_ERROR, "Reissue General Error"),
+    JWT_REISSUE_OLD("JWT_005", HttpStatus.INTERNAL_SERVER_ERROR, "Refresh Token Is Old"),
+    REISSUE_ERROR("JWT_006", HttpStatus.INTERNAL_SERVER_ERROR, "Reissue General Error"),
 
     //AUTHENTICATION - GENERAL
     UNAUTHENTICATED("SEC-001", HttpStatus.UNAUTHORIZED, "Unauthenticated"),

--- a/src/main/java/com/payper/server/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/payper/server/security/CustomAccessDeniedHandler.java
@@ -11,6 +11,7 @@ import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 import tools.jackson.databind.ObjectMapper;
 
+
 import java.io.IOException;
 
 @RequiredArgsConstructor

--- a/src/main/java/com/payper/server/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/payper/server/security/CustomAccessDeniedHandler.java
@@ -8,11 +8,13 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
 import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 
 @RequiredArgsConstructor
+@Component
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
     private final ObjectMapper objectMapper;
 

--- a/src/main/java/com/payper/server/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/payper/server/security/CustomAccessDeniedHandler.java
@@ -7,6 +7,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 import tools.jackson.databind.ObjectMapper;
@@ -25,8 +28,17 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
             HttpServletResponse response,
             AccessDeniedException accessDeniedException
     ) throws IOException, ServletException {
-        ApiResponse<String> failResponseDto =
-                ApiResponse.fail(ErrorCode.UNAUTHORIZED, accessDeniedException.getMessage());
+
+        ApiResponse<String> failResponseDto;
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if(authentication==null||!(authentication.isAuthenticated())) {
+            failResponseDto =
+                    ApiResponse.fail(ErrorCode.UNAUTHENTICATED, accessDeniedException.getMessage());
+        }
+        else{
+            failResponseDto =
+                    ApiResponse.fail(ErrorCode.UNAUTHORIZED, accessDeniedException.getMessage());
+        }
 
         response.setStatus(failResponseDto.getStatus());
         response.setContentType("application/json");

--- a/src/main/java/com/payper/server/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/payper/server/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,34 @@
+package com.payper.server.security;
+
+import com.payper.server.global.response.ApiResponse;
+import com.payper.server.global.response.ErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException, ServletException {
+        ApiResponse<String> failResponseDto =
+                ApiResponse.fail(ErrorCode.UNAUTHORIZED, accessDeniedException.getMessage());
+
+        response.setStatus(failResponseDto.getStatus());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        objectMapper.writeValue(response.getWriter(), failResponseDto);
+    }
+}

--- a/src/main/java/com/payper/server/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/payper/server/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,69 @@
+package com.payper.server.security;
+
+import com.payper.server.auth.exception.UserAuthenticationException;
+import com.payper.server.auth.jwt.exception.JwtValidAuthenticationException;
+import com.payper.server.global.response.ApiResponse;
+import com.payper.server.global.response.ErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.apache.catalina.User;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@RequiredArgsConstructor
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException, ServletException {
+
+        if (response.isCommitted()) {
+            return;
+        }
+
+        ErrorCode errorCode = resolveErrorCode(request, authException);
+
+        ApiResponse<Void> body = ApiResponse.fail(errorCode);
+
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        objectMapper.writeValue(response.getWriter(), body);
+    }
+
+    private ErrorCode resolveErrorCode(HttpServletRequest request, AuthenticationException ex) {
+
+        // 1) 내가 만든 커스텀 예외면 그대로 사용
+        if (ex instanceof JwtValidAuthenticationException jwtEx) {
+            return jwtEx.getErrorCode();
+        }
+        if(ex instanceof  UserAuthenticationException userEx) {
+            return userEx.getErrorCode();
+        }
+
+        // 3) 토큰이 아예 없거나(익명 접근) 등으로 발생하는 대표 케이스
+        if (ex instanceof InsufficientAuthenticationException) {
+            return ErrorCode.UNAUTHENTICATED;
+        }
+
+        // 4) 최후의 기본값
+        return ErrorCode.UNAUTHENTICATED;
+    }
+
+}

--- a/src/main/java/com/payper/server/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/payper/server/security/CustomAuthenticationEntryPoint.java
@@ -8,7 +8,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.apache.catalina.User;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.AuthenticationException;

--- a/src/main/java/com/payper/server/security/CustomUserDetailsService.java
+++ b/src/main/java/com/payper/server/security/CustomUserDetailsService.java
@@ -1,0 +1,35 @@
+package com.payper.server.security;
+
+import com.payper.server.auth.exception.UserAuthenticationException;
+import com.payper.server.global.response.ErrorCode;
+import com.payper.server.user.UserRepository;
+import com.payper.server.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String userIdentifier) throws UsernameNotFoundException {
+        User activeUser = getActiveUserByUserIdentifier(userIdentifier);
+        return new CustomUserDetails(activeUser);
+    }
+
+    public User getActiveUserByUserIdentifier(String userIdentifier) {
+        User user = userRepository.findByUserIdentifier(userIdentifier)
+                .orElseThrow(() -> new UserAuthenticationException(ErrorCode.USER_NOTFOUND));
+
+        if (!user.isActive()) {
+            throw new UserAuthenticationException(ErrorCode.USER_NOTFOUND);
+        }
+        return user;
+    }
+}

--- a/src/main/java/com/payper/server/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/payper/server/security/JwtAuthenticationFilter.java
@@ -34,7 +34,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             HttpServletResponse response,
             FilterChain filterChain
     ) throws ServletException, IOException {
-        System.out.println("JwtAuthenticationFilter.doFilterInternal");
+        //System.out.println("JwtAuthenticationFilter.doFilterInternal");
 
         String accessToken = jwtParseUtil.extractJwtTokenFromRequest(request);
 

--- a/src/main/java/com/payper/server/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/payper/server/security/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package com.payper.server.security;
+
+import com.payper.server.auth.jwt.util.JwtParseUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final RequestMatcher skipRequestMatcher;
+    private final JwtParseUtil jwtParseUtil;
+    private final AuthenticationManager authenticationManager;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return skipRequestMatcher.matches(request);
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        System.out.println("JwtAuthenticationFilter.doFilterInternal");
+
+        String accessToken = jwtParseUtil.extractJwtTokenFromRequest(request);
+
+        if (accessToken == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try{
+            Authentication requestAuth =
+                    UsernamePasswordAuthenticationToken.unauthenticated(null, accessToken);
+
+            Authentication authenticated =
+                    authenticationManager.authenticate(requestAuth);
+            SecurityContextHolder.getContext().setAuthentication(authenticated);
+            filterChain.doFilter(request, response);
+        }
+        catch(AuthenticationException e){
+            SecurityContextHolder.clearContext();
+            customAuthenticationEntryPoint.commence(request, response, e);
+        }
+    }
+}

--- a/src/main/java/com/payper/server/security/JwtAuthenticationProvider.java
+++ b/src/main/java/com/payper/server/security/JwtAuthenticationProvider.java
@@ -1,0 +1,42 @@
+package com.payper.server.security;
+
+import com.payper.server.auth.jwt.entity.JwtType;
+import com.payper.server.auth.jwt.exception.JwtValidAuthenticationException;
+import com.payper.server.auth.jwt.util.JwtParseUtil;
+import com.payper.server.global.response.ErrorCode;
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+    private final UserDetailsService userDetailsService;
+    private final JwtParseUtil jwtParseUtil;
+
+    @Override
+    public @Nullable Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        String accessToken = (String) authentication.getCredentials();
+
+        if (jwtParseUtil.getJwtType(accessToken) != JwtType.ACCESS) {
+            throw new JwtValidAuthenticationException(ErrorCode.JWT_ERROR);
+        }
+
+        String userIdentifier = jwtParseUtil.getUserIdentifier(accessToken);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(userIdentifier);
+
+        return UsernamePasswordAuthenticationToken.authenticated(userDetails, null, userDetails.getAuthorities());
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}
+

--- a/src/main/java/com/payper/server/security/SecurityConfig.java
+++ b/src/main/java/com/payper/server/security/SecurityConfig.java
@@ -1,21 +1,28 @@
 package com.payper.server.security;
 
+import com.payper.server.auth.jwt.util.JwtParseUtil;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import tools.jackson.databind.ObjectMapper;
 
 @Configuration
 @EnableWebSecurity
@@ -25,19 +32,26 @@ public class SecurityConfig {
     private RequestMatcher authenticatedRequestMatcher;
     private RequestMatcher adminRequestMatcher;
 
+    private final JwtAuthenticationProvider jwtAuthenticationProvider;
+    private final JwtParseUtil jwtParseUtil;
+
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
     @PostConstruct
     void init() {
         var requestMatcher =
                 PathPatternRequestMatcher.withDefaults().basePath("/");
 
         permitAllRequestMatcher = new OrRequestMatcher(
-                //requestMatcher.matcher("/**"),//<-테스트할 때는 이 내용 넣어주세요.
+                //requestMatcher.matcher("/**"),//<-개발할 때는 이 내용 넣어주세요.
                 requestMatcher.matcher(HttpMethod.GET, "/swagger-ui/**"),
                 requestMatcher.matcher(HttpMethod.GET, "/v3/api-docs/**"),
                 requestMatcher.matcher(HttpMethod.GET, "/favicon.ico"),
                 requestMatcher.matcher("/auth/**")
         );
         authenticatedRequestMatcher = new OrRequestMatcher(
+                requestMatcher.matcher("/**"),//<-개발할 때는 이 내용 빼주세요.
                 requestMatcher.matcher(HttpMethod.GET, "/me")
         );
         adminRequestMatcher = new OrRequestMatcher(
@@ -45,6 +59,29 @@ public class SecurityConfig {
         );
     }
 
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager() {
+        return new ProviderManager(
+                jwtAuthenticationProvider
+        );
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        RequestMatcher skipEndPoints =
+                permitAllRequestMatcher;
+        return new JwtAuthenticationFilter(
+                skipEndPoints,
+                jwtParseUtil,
+                authenticationManager(),
+                customAuthenticationEntryPoint
+        );
+    }
 
 
     @Bean
@@ -67,12 +104,18 @@ public class SecurityConfig {
                                 .requestMatchers(permitAllRequestMatcher)
                                 .permitAll()
                                 .requestMatchers(authenticatedRequestMatcher)
-                                .permitAll()
+                                .authenticated()
                                 .requestMatchers(adminRequestMatcher)
                                 .hasRole("ADMIN")
-                                .anyRequest().authenticated()
                 )
 
+                .addFilterAfter(jwtAuthenticationFilter(), LogoutFilter.class)
+
+                .exceptionHandling(
+                        configurer -> configurer
+                                .authenticationEntryPoint(customAuthenticationEntryPoint)
+                                .accessDeniedHandler(customAccessDeniedHandler)
+                )
 
                 .build();
     }

--- a/src/main/java/com/payper/server/security/SecurityConfig.java
+++ b/src/main/java/com/payper/server/security/SecurityConfig.java
@@ -44,14 +44,14 @@ public class SecurityConfig {
                 PathPatternRequestMatcher.withDefaults().basePath("/");
 
         permitAllRequestMatcher = new OrRequestMatcher(
-                //requestMatcher.matcher("/**"),//<-개발할 때는 이 내용 넣어주세요.
+                //requestMatcher.matcher("/**"),
                 requestMatcher.matcher(HttpMethod.GET, "/swagger-ui/**"),
                 requestMatcher.matcher(HttpMethod.GET, "/v3/api-docs/**"),
                 requestMatcher.matcher(HttpMethod.GET, "/favicon.ico"),
                 requestMatcher.matcher("/auth/**")
         );
         authenticatedRequestMatcher = new OrRequestMatcher(
-                requestMatcher.matcher("/**"),//<-개발할 때는 이 내용 빼주세요.
+                //requestMatcher.matcher("/**"),
                 requestMatcher.matcher(HttpMethod.GET, "/me")
         );
         adminRequestMatcher = new OrRequestMatcher(
@@ -73,8 +73,7 @@ public class SecurityConfig {
 
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        RequestMatcher skipEndPoints =
-                permitAllRequestMatcher;
+        RequestMatcher skipEndPoints = permitAllRequestMatcher;
         return new JwtAuthenticationFilter(
                 skipEndPoints,
                 jwtParseUtil,

--- a/src/test/java/com/payper/server/JwtModulesSpringBootIntegrationTest.java
+++ b/src/test/java/com/payper/server/JwtModulesSpringBootIntegrationTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -25,20 +26,25 @@ import static org.assertj.core.api.Assertions.*;
 @ActiveProfiles("test")
 class JwtModulesSpringBootIntegrationTest {
 
-    @Autowired JwtProperties jwtProperties;
+    @Autowired
+    JwtProperties jwtProperties;
 
-    @Autowired JwtTokenUtil jwtTokenUtil;
-    @Autowired JwtParseUtil jwtParseUtil;
+    @Autowired
+    JwtTokenUtil jwtTokenUtil;
+    @Autowired
+    JwtParseUtil jwtParseUtil;
 
-    @Autowired JwtRefreshTokenUtil jwtRefreshTokenUtil;
-    @Autowired RefreshTokenRepository refreshTokenRepository;
+    @Autowired
+    JwtRefreshTokenUtil jwtRefreshTokenUtil;
+    @Autowired
+    RefreshTokenRepository refreshTokenRepository;
 
     /**
      * ✅ 이 테스트는 "실제 MySQL 연동"이므로
-     *  - 각 테스트가 서로 간섭하지 않게 매번 DB를 비우고
-     *  - @Transactional이 적용된 테스트라면(기본 롤백)에도,
-     *    내부 util이 REQUIRES_NEW로 flush/commit을 때리며 남길 수 있어
-     *    BeforeEach에서 강제로 정리하는 방식이 안전함.
+     * - 각 테스트가 서로 간섭하지 않게 매번 DB를 비우고
+     * - @Transactional이 적용된 테스트라면(기본 롤백)에도,
+     * 내부 util이 REQUIRES_NEW로 flush/commit을 때리며 남길 수 있어
+     * BeforeEach에서 강제로 정리하는 방식이 안전함.
      */
     @BeforeEach
     void cleanDb() {
@@ -125,8 +131,8 @@ class JwtModulesSpringBootIntegrationTest {
     /**
      * ✅ DB 통합 플로우 테스트들은 '테스트 메서드 단위 트랜잭션' 안에서 실행되도록 @Transactional 부여
      * - 이 테스트 클래스 전체에 @Transactional을 걸지 않는 이유:
-     *   util 내부에 REQUIRES_NEW가 섞여 있으면 테스트 트랜잭션 롤백으로도 데이터가 남을 수 있어서
-     *   오히려 오해를 만들기 쉬움.
+     * util 내부에 REQUIRES_NEW가 섞여 있으면 테스트 트랜잭션 롤백으로도 데이터가 남을 수 있어서
+     * 오히려 오해를 만들기 쉬움.
      * - 대신: 각 테스트 시작 전 cleanDb()로 완전 격리
      */
     @Test
@@ -164,9 +170,11 @@ class JwtModulesSpringBootIntegrationTest {
 
         assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw1)).isNull();
 
-        RefreshTokenEntity found2 = jwtRefreshTokenUtil.getRefreshTokenEntity(raw2);
+        Optional<RefreshTokenEntity> found2 = jwtRefreshTokenUtil.getRefreshTokenEntity(raw2);
         assertThat(found2).isNotNull();
-        assertThat(found2.getUserIdentifier()).isEqualTo(userIdentifier);
+        found2.ifPresent(
+                refreshTokenEntity -> assertThat(refreshTokenEntity.getUserIdentifier()
+                ).isEqualTo(userIdentifier));
     }
 
     @Test


### PR DESCRIPTION
## 📌 개요
토큰 검증 후 DB에서 사용자 최신 상태/권한을 로딩하여 SecurityContext에 인증 객체를 세팅한다.
인증 이후 “권한”으로 엔드포인트 접근을 제어한다.

## 🔧 작업 내용
CustomUserDetailsService implements UserDetailsService 구현
+AuthenticationManager가 쓸 Provider 구현
JwtAuthenticationFilter(OncePerRequestFilter) 구현

loadUserByUsername 정책 결정 (username=userId? → 토큰 sub = userIdentifier)
유저 상태 체크(정지/탈퇴) 시 예외 정책 수립

Authorization 헤더 파싱(Bearer ) + 토큰 검증
-> 이전 이슈에서 구현

토큰 sub 기반으로 CustomUserDetailsService 통해 유저 로딩
UsernamePasswordAuthenticationToken 생성 후 SecurityContextHolder에 저장

permitAll 경로는 필터 스킵 처리
->필터 안에서 직접 스킵

JWT 관련 예외를 “JSON 에러 응답”으로 변환하는 처리 구성

필터를 SecurityFilterChain에 등록 (적절한 위치: UsernamePasswordAuthenticationFilter 이전 등)

role 모델(ROLE_USER/ROLE_ADMIN 등) 확정

Security 설정 또는 @PreAuthorize로 접근 정책 추가

메서드 시큐리티 사용 여부 결정 및 활성화

403 응답 규격 확인

## ✅ 체크리스트
보호된 API에 토큰 없이 접근 시 401

만료/서명오류 토큰은 명확한 JWT 에러로 응답

유효 토큰으로 접근 시 @AuthenticationPrincipal CustomUserDetails 사용 가능

권한 부족 시 403

권한 충족 시 정상 접근

=> 모두 확인 완료.

현재까지 인증에 있어서 생기는 대표적인 예외 케이스 6가지.
테스트로 모두 검증.

1카카오 조인, 로그인 시 oauthaccesstoken 이상하게
=>oauthexception -> 확인.

2멤버 db에서 지우고 accessToken그대로 보내기
=> member not found -> 확인.

3멤버 중복으로 가입
=> member duplicate -> 확인.

4unAuthorization error -> 확인.

5accessToken 이상하게
=> jwt 토큰 예외 -> jwtvalidauthentication filter에서 직접 잡아서 던져줘야한다.
custome authentication entry point의 commence 직접 호출
아니면 accesstoken을 해결하지 못한 계정을 인증이 안된 계정이라고 인식해
jwt예외를 포함 다른 예외를 InsufficientAuthenticationException로 처리한다.
-> 해결.

6만료된 accessToken
=> jwt expired error
5번 케이스와 같이 해결.

## 📝 기타 참고 사항
해당 브랜치는 베이스가 feat/#11입니다.

## 📎 관련 이슈
Close #12