### PR TITLE
[FEATURE #13]: Refresh / Logout 플로우 구현 (쿠키+RDB 저장 기반), 예외 처리 표준화 (401/403 + 도메인/JWT 에러 통일), 테스트 로깅 통합테스트

### DIFF
--- a/src/main/java/com/payper/server/auth/AuthController.java
+++ b/src/main/java/com/payper/server/auth/AuthController.java
@@ -3,16 +3,14 @@ package com.payper.server.auth;
 import com.payper.server.auth.dto.JoinRequest;
 import com.payper.server.auth.dto.LoginRequest;
 import com.payper.server.auth.dto.LoginSuccessResponse;
+import com.payper.server.auth.dto.ReissueSuccessResponse;
 import com.payper.server.global.response.ApiResponse;
 import com.payper.server.user.entity.AuthType;
 import com.payper.server.user.entity.User;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -46,8 +44,31 @@ public class AuthController {
         return issueTokensAndCreateResponse(user, response);
     }
 
-    private ResponseEntity<ApiResponse<LoginSuccessResponse>> issueTokensAndCreateResponse(User user, HttpServletResponse response) {
+    private ResponseEntity<ApiResponse<LoginSuccessResponse>>
+    issueTokensAndCreateResponse(User user, HttpServletResponse response) {
         String accessToken = authService.enrollNewAuthTokens(user, response);
         return ResponseEntity.ok(ApiResponse.ok(new LoginSuccessResponse(accessToken)));
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponse<ReissueSuccessResponse>> reissue(
+            @CookieValue(required = false) String refreshToken,
+            HttpServletResponse response
+    ){
+        String accessToken = authService.reissueAccessToken(refreshToken, response);
+
+        return ResponseEntity.ok(
+                ApiResponse.ok(new ReissueSuccessResponse(accessToken))
+        );
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<String>> logout(
+            @CookieValue(required = false) String refreshToken,
+            HttpServletResponse response
+    ) {
+        authService.clearRefreshTokenAndEntity(refreshToken, response);
+
+        return ResponseEntity.ok(ApiResponse.ok("logout success"));
     }
 }

--- a/src/main/java/com/payper/server/auth/AuthService.java
+++ b/src/main/java/com/payper/server/auth/AuthService.java
@@ -24,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.util.Date;
+import java.util.Optional;
 
 @Service
 @Transactional
@@ -90,11 +91,11 @@ public class AuthService {
             userIdentifier = jwtParseUtil.getUserIdentifier(refreshToken);
         } catch (JwtValidAuthenticationException e) {
             throw
-            switch (e.getErrorCode()) {
-                case JWT_ERROR -> new ReissueException(ErrorCode.JWT_REISSUE_ERROR);
-                case JWT_EXPIRED -> new ReissueException(ErrorCode.JWT_REISSUE_EXPIRED);
-                default -> new ReissueException(ErrorCode.REISSUE_ERROR);
-            };
+                    switch (e.getErrorCode()) {
+                        case JWT_ERROR -> new ReissueException(ErrorCode.JWT_REISSUE_ERROR);
+                        case JWT_EXPIRED -> new ReissueException(ErrorCode.JWT_REISSUE_EXPIRED);
+                        default -> new ReissueException(ErrorCode.REISSUE_ERROR);
+                    };
         }
 
         // 2) DB 존재 여부 확인 (해시 조회)
@@ -141,11 +142,10 @@ public class AuthService {
             return;
         }
 
-        try {
-            RefreshTokenEntity refreshTokenEntity = jwtRefreshTokenUtil.getRefreshTokenEntity(refreshToken);
-            jwtRefreshTokenUtil.deleteAllRefreshTokenEntity(refreshTokenEntity.getUserIdentifier());
-        } catch (Exception e) {
-            log.info("refreshToken invalid");
-        }
+        Optional<RefreshTokenEntity> refreshTokenEntity = jwtRefreshTokenUtil.getRefreshTokenEntity(refreshToken);
+        refreshTokenEntity.ifPresent(
+                r->
+                        jwtRefreshTokenUtil.deleteAllRefreshTokenEntity(r.getUserIdentifier())
+        );
     }
 }

--- a/src/main/java/com/payper/server/auth/AuthService.java
+++ b/src/main/java/com/payper/server/auth/AuthService.java
@@ -18,6 +18,7 @@ import com.payper.server.user.entity.User;
 import com.payper.server.user.entity.UserRole;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -27,6 +28,7 @@ import java.util.Date;
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class AuthService {
     private final UserService userService;
     private final KakaoOAuthUtilImpl kakaoOAuthUtil;
@@ -99,6 +101,8 @@ public class AuthService {
             existing = jwtRefreshTokenUtil.getRefreshTokenEntity(refreshToken);
         } catch (RuntimeException ex) {
             // 해시 과정/인코딩 문제 등 -> "토큰 이상"으로 처리
+            log.error("refresh token not found | hashing problem");
+
             throw new ReissueException(ErrorCode.JWT_REISSUE_ERROR);
         }
 
@@ -136,7 +140,8 @@ public class AuthService {
         try {
             RefreshTokenEntity refreshTokenEntity = jwtRefreshTokenUtil.getRefreshTokenEntity(refreshToken);
             jwtRefreshTokenUtil.deleteAllRefreshTokenEntity(refreshTokenEntity.getUserIdentifier());
-        } catch (Exception e) {//무시}
+        } catch (Exception e) {
+            log.info("refreshToken invalid");
         }
     }
 }

--- a/src/main/java/com/payper/server/auth/jwt/util/JwtRefreshTokenUtil.java
+++ b/src/main/java/com/payper/server/auth/jwt/util/JwtRefreshTokenUtil.java
@@ -2,6 +2,8 @@ package com.payper.server.auth.jwt.util;
 
 import com.payper.server.auth.jwt.RefreshTokenRepository;
 import com.payper.server.auth.jwt.entity.RefreshTokenEntity;
+import com.payper.server.auth.jwt.exception.ReissueException;
+import com.payper.server.global.response.ErrorCode;
 import io.jsonwebtoken.Jwts;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.Cookie;
@@ -73,7 +75,9 @@ public class JwtRefreshTokenUtil {
     public RefreshTokenEntity getRefreshTokenEntity(String refreshToken) {
         return refreshTokenRepository
                 .findByHashedRefreshToken(hashRefreshToken(refreshToken))
-                .orElse(null);
+                .orElseThrow(
+                        ()-> new IllegalStateException("Failed to find refresh token")
+                );
     }
 
 

--- a/src/main/java/com/payper/server/auth/jwt/util/JwtRefreshTokenUtil.java
+++ b/src/main/java/com/payper/server/auth/jwt/util/JwtRefreshTokenUtil.java
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.Base64;
 import java.util.Date;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -72,12 +73,9 @@ public class JwtRefreshTokenUtil {
         return count;
     }
 
-    public RefreshTokenEntity getRefreshTokenEntity(String refreshToken) {
+    public Optional<RefreshTokenEntity> getRefreshTokenEntity(String refreshToken) {
         return refreshTokenRepository
-                .findByHashedRefreshToken(hashRefreshToken(refreshToken))
-                .orElseThrow(
-                        ()-> new IllegalStateException("Failed to find refresh token")
-                );
+                .findByHashedRefreshToken(hashRefreshToken(refreshToken));
     }
 
 

--- a/src/main/java/com/payper/server/global/response/ErrorCode.java
+++ b/src/main/java/com/payper/server/global/response/ErrorCode.java
@@ -19,7 +19,8 @@ public enum ErrorCode {
     JWT_EXPIRED("JWT_002", HttpStatus.UNAUTHORIZED, "JWT Expired"),
     JWT_REISSUE_ERROR("JWT_003", HttpStatus.INTERNAL_SERVER_ERROR, "Refresh Token General Error"),
     JWT_REISSUE_EXPIRED("JWT_004", HttpStatus.INTERNAL_SERVER_ERROR, "Refresh Token Expired"),
-    REISSUE_ERROR("JWT_005", HttpStatus.INTERNAL_SERVER_ERROR, "Reissue General Error"),
+    JWT_REISSUE_OLD("JWT_005", HttpStatus.INTERNAL_SERVER_ERROR, "Refresh Token Is Old"),
+    REISSUE_ERROR("JWT_006", HttpStatus.INTERNAL_SERVER_ERROR, "Reissue General Error"),
 
     //AUTHENTICATION - GENERAL
     UNAUTHENTICATED("SEC-001", HttpStatus.UNAUTHORIZED, "Unauthenticated"),

--- a/src/main/java/com/payper/server/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/payper/server/security/CustomAccessDeniedHandler.java
@@ -7,6 +7,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 import tools.jackson.databind.ObjectMapper;
@@ -25,8 +28,17 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
             HttpServletResponse response,
             AccessDeniedException accessDeniedException
     ) throws IOException, ServletException {
-        ApiResponse<String> failResponseDto =
-                ApiResponse.fail(ErrorCode.UNAUTHORIZED, accessDeniedException.getMessage());
+
+        ApiResponse<String> failResponseDto;
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if(authentication==null||!(authentication.isAuthenticated())) {
+            failResponseDto =
+                    ApiResponse.fail(ErrorCode.UNAUTHENTICATED, accessDeniedException.getMessage());
+        }
+        else{
+            failResponseDto =
+                    ApiResponse.fail(ErrorCode.UNAUTHORIZED, accessDeniedException.getMessage());
+        }
 
         response.setStatus(failResponseDto.getStatus());
         response.setContentType("application/json");

--- a/src/test/java/com/payper/server/JwtModulesSpringBootIntegrationTest.java
+++ b/src/test/java/com/payper/server/JwtModulesSpringBootIntegrationTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -25,20 +26,25 @@ import static org.assertj.core.api.Assertions.*;
 @ActiveProfiles("test")
 class JwtModulesSpringBootIntegrationTest {
 
-    @Autowired JwtProperties jwtProperties;
+    @Autowired
+    JwtProperties jwtProperties;
 
-    @Autowired JwtTokenUtil jwtTokenUtil;
-    @Autowired JwtParseUtil jwtParseUtil;
+    @Autowired
+    JwtTokenUtil jwtTokenUtil;
+    @Autowired
+    JwtParseUtil jwtParseUtil;
 
-    @Autowired JwtRefreshTokenUtil jwtRefreshTokenUtil;
-    @Autowired RefreshTokenRepository refreshTokenRepository;
+    @Autowired
+    JwtRefreshTokenUtil jwtRefreshTokenUtil;
+    @Autowired
+    RefreshTokenRepository refreshTokenRepository;
 
     /**
      * ✅ 이 테스트는 "실제 MySQL 연동"이므로
-     *  - 각 테스트가 서로 간섭하지 않게 매번 DB를 비우고
-     *  - @Transactional이 적용된 테스트라면(기본 롤백)에도,
-     *    내부 util이 REQUIRES_NEW로 flush/commit을 때리며 남길 수 있어
-     *    BeforeEach에서 강제로 정리하는 방식이 안전함.
+     * - 각 테스트가 서로 간섭하지 않게 매번 DB를 비우고
+     * - @Transactional이 적용된 테스트라면(기본 롤백)에도,
+     * 내부 util이 REQUIRES_NEW로 flush/commit을 때리며 남길 수 있어
+     * BeforeEach에서 강제로 정리하는 방식이 안전함.
      */
     @BeforeEach
     void cleanDb() {
@@ -125,8 +131,8 @@ class JwtModulesSpringBootIntegrationTest {
     /**
      * ✅ DB 통합 플로우 테스트들은 '테스트 메서드 단위 트랜잭션' 안에서 실행되도록 @Transactional 부여
      * - 이 테스트 클래스 전체에 @Transactional을 걸지 않는 이유:
-     *   util 내부에 REQUIRES_NEW가 섞여 있으면 테스트 트랜잭션 롤백으로도 데이터가 남을 수 있어서
-     *   오히려 오해를 만들기 쉬움.
+     * util 내부에 REQUIRES_NEW가 섞여 있으면 테스트 트랜잭션 롤백으로도 데이터가 남을 수 있어서
+     * 오히려 오해를 만들기 쉬움.
      * - 대신: 각 테스트 시작 전 cleanDb()로 완전 격리
      */
     @Test
@@ -164,9 +170,11 @@ class JwtModulesSpringBootIntegrationTest {
 
         assertThat(jwtRefreshTokenUtil.getRefreshTokenEntity(raw1)).isNull();
 
-        RefreshTokenEntity found2 = jwtRefreshTokenUtil.getRefreshTokenEntity(raw2);
+        Optional<RefreshTokenEntity> found2 = jwtRefreshTokenUtil.getRefreshTokenEntity(raw2);
         assertThat(found2).isNotNull();
-        assertThat(found2.getUserIdentifier()).isEqualTo(userIdentifier);
+        found2.ifPresent(
+                refreshTokenEntity -> assertThat(refreshTokenEntity.getUserIdentifier()
+                ).isEqualTo(userIdentifier));
     }
 
     @Test


### PR DESCRIPTION
## 📌 개요
access 만료를 refresh로 복구하고, 로그아웃 시 refresh를 폐기한다.
인증/인가/토큰/외부인증 실패를 전부 “일관된 JSON 에러”로 반환한다.

## 🔧 작업 내용
/auth/refresh 구현: refresh 검증 → DB 조회 → 새 access 발급

(선택) 로테이션 정책 적용: 기존 refresh 폐기 + 새 refresh 저장

/auth/logout 구현: refresh 폐기(단일 디바이스/전체 정책에 맞게)

refresh 저장값 해시 저장 여부 결정

AuthenticationEntryPoint로 401 JSON 응답 통일

AccessDeniedHandler로 403 JSON 응답 통일

@RestControllerAdvice로 도메인 예외 공통 처리

에러 코드/메시지/traceId 포함 규칙 적용

필터 레벨 예외와 컨트롤러 레벨 예외 응답 포맷 일치시키기

완료 조건 (DoD)

refresh로 access 재발급 가능

logout 후 refresh 재사용 불가

모든 실패 케이스가 동일한 포맷(JSON)으로 내려온다

“JWT 오류 / 인증 실패 / 인가 실패”가 구분된다

## ✅ 체크리스트
JWT 단위 테스트(만료/서명/클레임)

CustomUserDetailsService 테스트(유저 상태/권한/예외)

필터/시큐리티 통합 테스트(401/403/정상)

auth API 테스트(join/login/refresh/logout)

## 📝 기타 참고 사항
- 주의할 점, 추후 리팩토링 필요성 등

## 📎 관련 이슈
Close #13