### PR TITLE
[FEATURE #14]: post 도메인 기본 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	//implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/payper/server/global/response/ApiResponse.java
+++ b/src/main/java/com/payper/server/global/response/ApiResponse.java
@@ -12,6 +12,15 @@ public class ApiResponse<T> {
     private final T data;
     private final ExceptionDto error;
 
+    public static <T> ApiResponse<T> ok() {
+        return ApiResponse
+                .<T>builder()
+                .status(HttpStatus.OK.value())
+                .data(null)
+                .error(null)
+                .build();
+    }
+
     public static <T> ApiResponse<T> ok(@Nullable T data) {
         return ApiResponse
                 .<T>builder()

--- a/src/main/java/com/payper/server/global/response/ErrorCode.java
+++ b/src/main/java/com/payper/server/global/response/ErrorCode.java
@@ -12,8 +12,19 @@ public enum ErrorCode {
     UNAUTHORIZED("GEN-002", HttpStatus.UNAUTHORIZED, "Unauthorized"),
     NOT_FOUND("GEN-003", HttpStatus.NOT_FOUND, "Not Found"),
     CONFLICT("GEN-004", HttpStatus.CONFLICT, "Conflict"),
-    INTERNAL_SERVER_ERROR("GEN-005", HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error");
+    INTERNAL_SERVER_ERROR("GEN-005", HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
 
+    // USER
+    USER_NOT_FOUND("USER-001", HttpStatus.NOT_FOUND, "User Not Found"),
+    NOT_POSTING_USER("USER-002", HttpStatus.FORBIDDEN, "Not Posting User"),
+
+    // POST
+    POST_NOT_FOUND("POST-001", HttpStatus.NOT_FOUND, "Post Not Found"),
+
+    // MERCHANT
+    MERCHANT_NOT_FOUND("MERCHANT-001", HttpStatus.NOT_FOUND, "Merchant Not Found")
+
+    ;
 
     private final String code;
     private final HttpStatus status;

--- a/src/main/java/com/payper/server/merchant/controller/MerchantController.java
+++ b/src/main/java/com/payper/server/merchant/controller/MerchantController.java
@@ -1,0 +1,34 @@
+package com.payper.server.merchant.controller;
+
+import com.payper.server.global.response.ApiResponse;
+import com.payper.server.post.dto.PostRequest;
+import com.payper.server.post.service.PostService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/merchants")
+@RequiredArgsConstructor
+public class MerchantController {
+    private final PostService postService;
+
+    /**
+     * 게시글 작성
+     * 가맹점에 대해 글을 작성함
+     * 가맹점 리스트에서 가맹점을 선택해서 해당 가맹점의 id를 넘겨 받음
+     * TODO 가맹점이 없을 때는 어떻게 해야할까?
+     *
+     * 가입된 사용자만 글을 작성할 수 있음
+     */
+    @PostMapping("/{merchantId}/posts")
+    public ResponseEntity<ApiResponse<Long>> createPost(
+            // TODO @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long merchantId,
+            @RequestBody @Valid PostRequest.CreatePost request
+    ) {
+        Long postId = postService.createPost(1L, merchantId, request);
+        return ResponseEntity.status(201).body(ApiResponse.created(postId));
+    }
+}

--- a/src/main/java/com/payper/server/merchant/entity/Merchant.java
+++ b/src/main/java/com/payper/server/merchant/entity/Merchant.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Merchant {
+public class Merchant { // TODO 가맹점이 삭제되면 해당 가맹점에 등록된 post는??
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/payper/server/merchant/entity/Merchant.java
+++ b/src/main/java/com/payper/server/merchant/entity/Merchant.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Merchant { // TODO 가맹점이 삭제되면 해당 가맹점에 등록된 post는??
+public class Merchant {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/payper/server/merchant/repository/MerchantRepository.java
+++ b/src/main/java/com/payper/server/merchant/repository/MerchantRepository.java
@@ -1,0 +1,9 @@
+package com.payper.server.merchant.repository;
+
+import com.payper.server.merchant.entity.Merchant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MerchantRepository extends JpaRepository<Merchant, Long> {
+}

--- a/src/main/java/com/payper/server/post/controller/PostController.java
+++ b/src/main/java/com/payper/server/post/controller/PostController.java
@@ -1,0 +1,104 @@
+package com.payper.server.post.controller;
+
+import com.payper.server.post.dto.PostRequest;
+import com.payper.server.post.dto.PostResponse;
+import com.payper.server.post.dto.PostSortType;
+import com.payper.server.post.entity.PostType;
+import com.payper.server.post.service.PostService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/posts")
+@RequiredArgsConstructor
+public class PostController {
+    private final PostService postService;
+
+    /**
+     * 게시글 작성
+     * 가맹점에 대해 글을 작성함
+     * 가맹점 리스트에서 가맹점을 선택해서 해당 가맹점의 id를 넘겨 받음
+     * TODO 가맹점이 없을 때는 어떻게 해야할까?
+     *
+     * 가입된 사용자만 글을 작성할 수 있음
+     */
+    @PostMapping("/merchants/{merchantId}") // TODO: 흠 RESTFUL한 URL은 아닌 것 같음, posts가 뒤로 가는 게 맞는 것 같음
+    public ResponseEntity<Long> createPost(
+            // TODO @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long merchantId,
+            @RequestBody @Valid PostRequest.CreatePost request
+    ) {
+        Long postId = postService.createPost(1L, merchantId, request);
+        return ResponseEntity.status(201).body(postId);
+    }
+
+    /**
+     * 게시글 수정
+     * 작성자만 수정 가능
+     */
+    @PutMapping("/{postId}")
+    public ResponseEntity<Void> updatePost(
+            // TODO @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long postId,
+            @RequestBody @Valid PostRequest.UpdatePost request
+    ) {
+        postService.updatePost(1L, postId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 게시글 삭제
+     * 작성자만 삭제 가능
+     * TODO 댓글도 같이 soft delete
+     */
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<Void> deletePost(
+            // TODO @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long postId
+    ) {
+        postService.deletePost(1L, postId);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 단일 게시글 조회
+     *
+     * 삭제되지 않은 글만 조회함
+     */
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostResponse.postDetail> getPostDetail(@PathVariable Long postId) {
+        PostResponse.postDetail response = postService.getPostDetail(postId);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 게시글 리스트 조회
+     *
+     * 필터링 조건
+     * 가맹점, postType
+     *
+     * 정렬 조건
+     * 생성 순, 댓글 수, 좋아요 수, 조회 수
+     *
+     * 페이지네이션
+     */
+    @GetMapping()
+    public ResponseEntity<Page<PostResponse.postList>> getPosts(
+            @RequestParam(required = false) Long merchantId,
+            @RequestParam(required = false) PostType type,
+            @RequestParam(defaultValue = "POSTING_DATE") PostSortType sort,
+            @RequestParam(defaultValue = "DESC") Sort.Direction direction,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, sort.toSort(direction));
+        Page<PostResponse.postList> response = postService.getPosts(merchantId, type, pageable);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/payper/server/post/controller/PostController.java
+++ b/src/main/java/com/payper/server/post/controller/PostController.java
@@ -22,24 +22,6 @@ public class PostController {
     private final PostService postService;
 
     /**
-     * 게시글 작성
-     * 가맹점에 대해 글을 작성함
-     * 가맹점 리스트에서 가맹점을 선택해서 해당 가맹점의 id를 넘겨 받음
-     * TODO 가맹점이 없을 때는 어떻게 해야할까?
-     *
-     * 가입된 사용자만 글을 작성할 수 있음
-     */
-    @PostMapping("/merchants/{merchantId}") // TODO: 흠 RESTFUL한 URL은 아닌 것 같음, posts가 뒤로 가는 게 맞는 것 같음
-    public ResponseEntity<ApiResponse<Long>> createPost(
-            // TODO @AuthenticationPrincipal CustomUserDetails user,
-            @PathVariable Long merchantId,
-            @RequestBody @Valid PostRequest.CreatePost request
-    ) {
-        Long postId = postService.createPost(1L, merchantId, request);
-        return ResponseEntity.status(201).body(ApiResponse.created(postId));
-    }
-
-    /**
      * 게시글 수정
      * 작성자만 수정 가능
      */

--- a/src/main/java/com/payper/server/post/controller/PostController.java
+++ b/src/main/java/com/payper/server/post/controller/PostController.java
@@ -63,7 +63,7 @@ public class PostController {
             @PathVariable Long postId
     ) {
         postService.deletePost(1L, postId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     /**
@@ -72,8 +72,8 @@ public class PostController {
      * 삭제되지 않은 글만 조회함
      */
     @GetMapping("/{postId}")
-    public ResponseEntity<PostResponse.postDetail> getPostDetail(@PathVariable Long postId) {
-        PostResponse.postDetail response = postService.getPostDetail(postId);
+    public ResponseEntity<PostResponse.PostDetail> getPostDetail(@PathVariable Long postId) {
+        PostResponse.PostDetail response = postService.getPostDetail(postId);
         return ResponseEntity.ok(response);
     }
 
@@ -89,7 +89,7 @@ public class PostController {
      * 페이지네이션
      */
     @GetMapping()
-    public ResponseEntity<Page<PostResponse.postList>> getPosts(
+    public ResponseEntity<Page<PostResponse.PostList>> getPosts(
             @RequestParam(required = false) Long merchantId,
             @RequestParam(required = false) PostType type,
             @RequestParam(defaultValue = "POSTING_DATE") PostSortType sort,
@@ -98,7 +98,7 @@ public class PostController {
             @RequestParam(defaultValue = "10") int size
     ) {
         Pageable pageable = PageRequest.of(page, size, sort.toSort(direction));
-        Page<PostResponse.postList> response = postService.getPosts(merchantId, type, pageable);
+        Page<PostResponse.PostList> response = postService.getPosts(merchantId, type, pageable);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/payper/server/post/controller/PostController.java
+++ b/src/main/java/com/payper/server/post/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.payper.server.post.controller;
 
+import com.payper.server.global.response.ApiResponse;
 import com.payper.server.post.dto.PostRequest;
 import com.payper.server.post.dto.PostResponse;
 import com.payper.server.post.dto.PostSortType;
@@ -29,13 +30,13 @@ public class PostController {
      * 가입된 사용자만 글을 작성할 수 있음
      */
     @PostMapping("/merchants/{merchantId}") // TODO: 흠 RESTFUL한 URL은 아닌 것 같음, posts가 뒤로 가는 게 맞는 것 같음
-    public ResponseEntity<Long> createPost(
+    public ResponseEntity<ApiResponse<Long>> createPost(
             // TODO @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable Long merchantId,
             @RequestBody @Valid PostRequest.CreatePost request
     ) {
         Long postId = postService.createPost(1L, merchantId, request);
-        return ResponseEntity.status(201).body(postId);
+        return ResponseEntity.status(201).body(ApiResponse.created(postId));
     }
 
     /**
@@ -43,13 +44,13 @@ public class PostController {
      * 작성자만 수정 가능
      */
     @PutMapping("/{postId}")
-    public ResponseEntity<Void> updatePost(
+    public ResponseEntity<ApiResponse<Void>> updatePost(
             // TODO @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable Long postId,
             @RequestBody @Valid PostRequest.UpdatePost request
     ) {
         postService.updatePost(1L, postId, request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.ok());
     }
 
     /**
@@ -58,12 +59,12 @@ public class PostController {
      * TODO 댓글도 같이 soft delete
      */
     @DeleteMapping("/{postId}")
-    public ResponseEntity<Void> deletePost(
+    public ResponseEntity<ApiResponse<Void>> deletePost(
             // TODO @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable Long postId
     ) {
         postService.deletePost(1L, postId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok());
     }
 
     /**
@@ -72,9 +73,9 @@ public class PostController {
      * 삭제되지 않은 글만 조회함
      */
     @GetMapping("/{postId}")
-    public ResponseEntity<PostResponse.PostDetail> getPostDetail(@PathVariable Long postId) {
+    public ResponseEntity<ApiResponse<PostResponse.PostDetail>> getPostDetail(@PathVariable Long postId) {
         PostResponse.PostDetail response = postService.getPostDetail(postId);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
     /**
@@ -89,7 +90,7 @@ public class PostController {
      * 페이지네이션
      */
     @GetMapping()
-    public ResponseEntity<Page<PostResponse.PostList>> getPosts(
+    public ResponseEntity<ApiResponse<Page<PostResponse.PostList>>> getPosts(
             @RequestParam(required = false) Long merchantId,
             @RequestParam(required = false) PostType type,
             @RequestParam(defaultValue = "POSTING_DATE") PostSortType sort,
@@ -99,6 +100,6 @@ public class PostController {
     ) {
         Pageable pageable = PageRequest.of(page, size, sort.toSort(direction));
         Page<PostResponse.PostList> response = postService.getPosts(merchantId, type, pageable);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 }

--- a/src/main/java/com/payper/server/post/dto/PostRequest.java
+++ b/src/main/java/com/payper/server/post/dto/PostRequest.java
@@ -1,0 +1,36 @@
+package com.payper.server.post.dto;
+
+import com.payper.server.post.entity.PostType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public class PostRequest {
+
+    /**
+     * 게시글 작성 DTO
+     */
+    public record CreatePost(
+            @NotNull(message = "게시글의 타입을 선택해주세요.")
+            PostType type,
+
+            @NotBlank(message = "제목을 적어주세요.")
+            String title,
+
+            @NotBlank(message = "내용을 적어주세요.")
+            @Size(max = 5500000, message = "내용은 500만자 이내로 적어주세요.")
+            String content
+    ) {}
+
+    /**
+     * 게시글 수정 DTO
+     */
+    public record UpdatePost(
+            @NotBlank(message = "제목을 적어주세요.")
+            String title,
+
+            @NotBlank(message = "내용을 적어주세요.")
+            @Size(max = 5500000, message = "내용은 500만자 이내로 적어주세요.")
+            String content
+    ) {}
+}

--- a/src/main/java/com/payper/server/post/dto/PostResponse.java
+++ b/src/main/java/com/payper/server/post/dto/PostResponse.java
@@ -10,7 +10,7 @@ public class PostResponse {
     /**
      * 게시글 단일 조회 DTO
      */
-    public record postDetail(
+    public record PostDetail(
             Long id,
             String authorName, /* 작성자 이름 */
             String merchantName, /* 가맹점명 */
@@ -23,8 +23,8 @@ public class PostResponse {
             LocalDateTime createdAt, /* 글 작성 시간 */
             LocalDateTime updatedAt /* 글 수정 시간 */
     ) {
-        public static postDetail from(Post post) {
-            return new postDetail(
+        public static PostDetail from(Post post) {
+            return new PostDetail(
                     post.getId(),
                     post.getAuthor().getName(),
                     post.getMerchant().getName(),
@@ -43,7 +43,7 @@ public class PostResponse {
     /**
      * 게시글 리스트 조회 DTO
      */
-    public record postList(
+    public record PostList(
             Long id,
             String authorName, /* 작성자 이름 */
             String merchantName, /* 가맹점명 */
@@ -55,8 +55,8 @@ public class PostResponse {
             LocalDateTime createdAt /* 글 작성 시간 */
 
     ) {
-        public static postList from(Post post) {
-            return new postList(
+        public static PostList from(Post post) {
+            return new PostList(
                     post.getId(),
                     post.getAuthor().getName(),
                     post.getMerchant().getName(),

--- a/src/main/java/com/payper/server/post/dto/PostResponse.java
+++ b/src/main/java/com/payper/server/post/dto/PostResponse.java
@@ -1,0 +1,72 @@
+package com.payper.server.post.dto;
+
+import com.payper.server.post.entity.Post;
+import com.payper.server.post.entity.PostType;
+
+import java.time.LocalDateTime;
+
+public class PostResponse {
+
+    /**
+     * 게시글 단일 조회 DTO
+     */
+    public record postDetail(
+            Long id,
+            String authorName, /* 작성자 이름 */
+            String merchantName, /* 가맹점명 */
+            PostType type, /* 게시글 타입 */
+            String title, /* 제목 */
+            String content, /* 내용 */
+            long commentCount, /* 댓글 수 */
+            long viewCount, /* 조회 수 */
+            long likeCount, /* 좋아요 수 */
+            LocalDateTime createdAt, /* 글 작성 시간 */
+            LocalDateTime updatedAt /* 글 수정 시간 */
+    ) {
+        public static postDetail from(Post post) {
+            return new postDetail(
+                    post.getId(),
+                    post.getAuthor().getName(),
+                    post.getMerchant().getName(),
+                    post.getType(),
+                    post.getTitle(),
+                    post.getContent(),
+                    post.getCommentCount(),
+                    post.getViewCount(),
+                    post.getLikeCount(),
+                    post.getCreatedAt(),
+                    post.getUpdatedAt()
+            );
+        }
+    }
+
+    /**
+     * 게시글 리스트 조회 DTO
+     */
+    public record postList(
+            Long id,
+            String authorName, /* 작성자 이름 */
+            String merchantName, /* 가맹점명 */
+            PostType type, /* 게시글 타입 */
+            String title, /* 제목 */
+            long commentCount, /* 댓글 수 */
+            long viewCount, /* 조회 수 */
+            long likeCount, /* 좋아요 수 */
+            LocalDateTime createdAt /* 글 작성 시간 */
+
+    ) {
+        public static postList from(Post post) {
+            return new postList(
+                    post.getId(),
+                    post.getAuthor().getName(),
+                    post.getMerchant().getName(),
+                    post.getType(),
+                    post.getTitle(),
+                    post.getCommentCount(),
+                    post.getViewCount(),
+                    post.getLikeCount(),
+                    post.getCreatedAt()
+            );
+        }
+    }
+}

--- a/src/main/java/com/payper/server/post/dto/PostSortType.java
+++ b/src/main/java/com/payper/server/post/dto/PostSortType.java
@@ -1,0 +1,21 @@
+package com.payper.server.post.dto;
+
+import org.springframework.data.domain.Sort;
+
+public enum PostSortType {
+
+    POSTING_DATE("createdAt"),
+    COMMENT_COUNT("commentCount"),
+    LIKE_COUNT("likeCount"),
+    VIEW_COUNT("viewCount");
+
+    private final String property;
+
+    PostSortType(String property) {
+        this.property = property;
+    }
+
+    public Sort toSort(Sort.Direction direction) {
+        return Sort.by(direction, property);
+    }
+}

--- a/src/main/java/com/payper/server/post/entity/Post.java
+++ b/src/main/java/com/payper/server/post/entity/Post.java
@@ -121,8 +121,12 @@ public class Post extends BaseTimeEntity {
      * soft delete
      */
     public void delete() {
+        if (this.isDeleted) { // 멱등성 고려 처리
+            return;
+        }
+
         this.isDeleted = true;
-        this.deletedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        this.deletedAt = LocalDateTime.now();
     }
 
     /**
@@ -131,5 +135,20 @@ public class Post extends BaseTimeEntity {
     public void inactivate() {
         this.isInactive = true;
         this.inactiveAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+    }
+
+    public static Post create(User author, Merchant merchant, PostType type, String title, String content) {
+        return Post.builder()
+                .author(author)
+                .merchant(merchant)
+                .type(type)
+                .title(title)
+                .content(content)
+                .build();
+    }
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
     }
 }

--- a/src/main/java/com/payper/server/post/repository/PostRepository.java
+++ b/src/main/java/com/payper/server/post/repository/PostRepository.java
@@ -1,0 +1,40 @@
+package com.payper.server.post.repository;
+
+import com.payper.server.post.entity.Post;
+import com.payper.server.post.entity.PostType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+    Optional<Post> findByIdAndIsDeletedFalse(Long id);
+
+    @Query(
+        value = """
+          select p from Post p
+          join fetch p.author
+          join fetch p.merchant
+          where p.isDeleted = false
+            and (:merchantId IS NULL or p.merchant.id = :merchantId)
+            and (:type IS NULL or p.type = :type)
+        """,
+        countQuery = """
+          select count(p) from Post p
+          where p.isDeleted = false
+            and (:merchantId IS NULL or p.merchant.id = :merchantId)
+            and (:type IS NULL or p.type = :type)
+        """
+    )
+    Page<Post> findActivePostsByCondition(
+            @Param("merchantId") Long merchantId,
+            @Param("type") PostType type,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/payper/server/post/service/PostService.java
+++ b/src/main/java/com/payper/server/post/service/PostService.java
@@ -104,7 +104,7 @@ public class PostService {
      * 게시글 단일 조회
      */
     @Transactional(readOnly = true)
-    public PostResponse.postDetail getPostDetail(Long postId) {
+    public PostResponse.PostDetail getPostDetail(Long postId) {
         // 게시글 조회
         Post post = postRepository.findByIdAndIsDeletedFalse(postId)
                 .orElseThrow(() -> {
@@ -112,17 +112,17 @@ public class PostService {
                     return new RuntimeException();
                 });
 
-        return PostResponse.postDetail.from(post);
+        return PostResponse.PostDetail.from(post);
     }
 
     /**
      * 게시글 리스트 조회
      */
     @Transactional(readOnly = true)
-    public Page<PostResponse.postList> getPosts(Long merchantId, PostType type, Pageable pageable) {
+    public Page<PostResponse.PostList> getPosts(Long merchantId, PostType type, Pageable pageable) {
         Page<Post> posts = postRepository.findActivePostsByCondition(merchantId, type, pageable);
 
         log.info("post 조회 완료 {}", posts);
-        return posts.map(PostResponse.postList::from);
+        return posts.map(PostResponse.PostList::from);
     }
 }

--- a/src/main/java/com/payper/server/post/service/PostService.java
+++ b/src/main/java/com/payper/server/post/service/PostService.java
@@ -1,6 +1,5 @@
 package com.payper.server.post.service;
 
-import com.payper.server.comment.repository.CommentRepository;
 import com.payper.server.merchant.entity.Merchant;
 import com.payper.server.merchant.repository.MerchantRepository;
 import com.payper.server.post.dto.PostRequest;
@@ -25,8 +24,7 @@ public class PostService {
     private final UserRepository userRepository;
     private final PostRepository postRepository;
     private final MerchantRepository merchantRepository;
-    private final CommentRepository commentRepository;
-    
+
     /**
      * 게시글 작성
      */

--- a/src/main/java/com/payper/server/post/service/PostService.java
+++ b/src/main/java/com/payper/server/post/service/PostService.java
@@ -1,0 +1,130 @@
+package com.payper.server.post.service;
+
+import com.payper.server.comment.repository.CommentRepository;
+import com.payper.server.merchant.entity.Merchant;
+import com.payper.server.merchant.repository.MerchantRepository;
+import com.payper.server.post.dto.PostRequest;
+import com.payper.server.post.dto.PostResponse;
+import com.payper.server.post.entity.Post;
+import com.payper.server.post.entity.PostType;
+import com.payper.server.post.repository.PostRepository;
+import com.payper.server.user.entity.User;
+import com.payper.server.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final MerchantRepository merchantRepository;
+    private final CommentRepository commentRepository;
+    
+    /**
+     * 게시글 작성
+     */
+    @Transactional
+    public Long createPost(Long userId, Long merchantId, PostRequest.CreatePost request) {
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> {
+                    log.error("사용자 조회 실패 - userId: {}", userId);
+                    return new RuntimeException();
+                });
+
+        // 가맹점 조회
+        Merchant merchant = merchantRepository.findById(merchantId)
+                .orElseThrow(() -> {
+                    log.error("가맹점 조회 실패 - merchantId: {}", merchantId);
+                    return new RuntimeException();
+                });
+
+        // 게시글 생성
+        Post post = Post.create(user, merchant, request.type(), request.title(), request.content());
+        postRepository.save(post);
+
+        log.info("게시글 생성 완료 - postId: {}, userId: {}, merchantId: {}", post.getId(), userId, merchantId);
+        return post.getId();
+    }
+
+    /**
+     * 게시글 수정
+     */
+    @Transactional
+    public void updatePost(Long userId, Long postId, PostRequest.UpdatePost request) {
+        // 게시글 조회
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> {
+                    log.error("게시글 조회 실패 - postId: {}", postId);
+                    return new RuntimeException();
+                });
+
+        // 게시글 수정 권한 조회
+        if(!userId.equals(post.getAuthor().getId())) {
+            throw new RuntimeException();
+        }
+
+        // 게시글 수정
+        post.update(request.title(), request.content());
+
+        log.info("게시글 수정 완료 - postId: {}", post.getId());
+    }
+
+    /**
+     * 게시글 삭제
+     */
+    @Transactional
+    public void deletePost(Long userId, Long postId) {
+        // 게시글 조회
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> {
+                    log.error("게시글 조회 실패 - postId: {}", postId);
+                    return new RuntimeException();
+                });
+
+        // 게시글 삭제 권한 조회
+        if(!userId.equals(post.getAuthor().getId())) {
+            throw new RuntimeException();
+        }
+
+        // 게시글 삭제
+        post.delete();
+        log.info("게시글 삭제 완료 - postId: {}", post.getId());
+
+        // TODO 댓글 삭제 (대댓글도 삭제)
+//        commentRepository.softDeleteByPostId(postId);
+    }
+
+    /**
+     * 게시글 단일 조회
+     */
+    @Transactional(readOnly = true)
+    public PostResponse.postDetail getPostDetail(Long postId) {
+        // 게시글 조회
+        Post post = postRepository.findByIdAndIsDeletedFalse(postId)
+                .orElseThrow(() -> {
+                    log.error("게시글 조회 실패 - postId: {}", postId);
+                    return new RuntimeException();
+                });
+
+        return PostResponse.postDetail.from(post);
+    }
+
+    /**
+     * 게시글 리스트 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<PostResponse.postList> getPosts(Long merchantId, PostType type, Pageable pageable) {
+        Page<Post> posts = postRepository.findActivePostsByCondition(merchantId, type, pageable);
+
+        log.info("post 조회 완료 {}", posts);
+        return posts.map(PostResponse.postList::from);
+    }
+}

--- a/src/main/java/com/payper/server/post/service/PostService.java
+++ b/src/main/java/com/payper/server/post/service/PostService.java
@@ -1,5 +1,7 @@
 package com.payper.server.post.service;
 
+import com.payper.server.global.exception.ApiException;
+import com.payper.server.global.response.ErrorCode;
 import com.payper.server.merchant.entity.Merchant;
 import com.payper.server.merchant.repository.MerchantRepository;
 import com.payper.server.post.dto.PostRequest;
@@ -32,17 +34,11 @@ public class PostService {
     public Long createPost(Long userId, Long merchantId, PostRequest.CreatePost request) {
         // 사용자 조회
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> {
-                    log.error("사용자 조회 실패 - userId: {}", userId);
-                    return new RuntimeException();
-                });
+                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
 
         // 가맹점 조회
         Merchant merchant = merchantRepository.findById(merchantId)
-                .orElseThrow(() -> {
-                    log.error("가맹점 조회 실패 - merchantId: {}", merchantId);
-                    return new RuntimeException();
-                });
+                .orElseThrow(() -> new ApiException(ErrorCode.MERCHANT_NOT_FOUND));
 
         // 게시글 생성
         Post post = Post.create(user, merchant, request.type(), request.title(), request.content());
@@ -59,14 +55,11 @@ public class PostService {
     public void updatePost(Long userId, Long postId, PostRequest.UpdatePost request) {
         // 게시글 조회
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> {
-                    log.error("게시글 조회 실패 - postId: {}", postId);
-                    return new RuntimeException();
-                });
+                .orElseThrow(() -> new ApiException(ErrorCode.POST_NOT_FOUND));
 
         // 게시글 수정 권한 조회
         if(!userId.equals(post.getAuthor().getId())) {
-            throw new RuntimeException();
+            throw new ApiException(ErrorCode.NOT_POSTING_USER);
         }
 
         // 게시글 수정
@@ -82,14 +75,11 @@ public class PostService {
     public void deletePost(Long userId, Long postId) {
         // 게시글 조회
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> {
-                    log.error("게시글 조회 실패 - postId: {}", postId);
-                    return new RuntimeException();
-                });
+                .orElseThrow(() -> new ApiException(ErrorCode.POST_NOT_FOUND));
 
         // 게시글 삭제 권한 조회
         if(!userId.equals(post.getAuthor().getId())) {
-            throw new RuntimeException();
+            throw new ApiException(ErrorCode.NOT_POSTING_USER);
         }
 
         // 게시글 삭제
@@ -107,10 +97,7 @@ public class PostService {
     public PostResponse.PostDetail getPostDetail(Long postId) {
         // 게시글 조회
         Post post = postRepository.findByIdAndIsDeletedFalse(postId)
-                .orElseThrow(() -> {
-                    log.error("게시글 조회 실패 - postId: {}", postId);
-                    return new RuntimeException();
-                });
+                .orElseThrow(() -> new ApiException(ErrorCode.POST_NOT_FOUND));
 
         return PostResponse.PostDetail.from(post);
     }

--- a/src/main/java/com/payper/server/user/repository/UserRepository.java
+++ b/src/main/java/com/payper/server/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.payper.server.user.repository;
+
+import com.payper.server.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}


### PR DESCRIPTION
## 📌 개요
Post 도메인에 대한 CRUD 기능 API를 구현했습니다.

## 🔧 작업 내용
- 게시글 작성 API 구현
- 게시글 수정 API 구현
- 게시글 삭제(soft delete) API 구현
- 게시글 단일 조회 API 구현 (삭제되지 않은 글만 조회)
- 게시글 리스트 조회 API 구현
    - 가맹점 / 게시글 타입 필터링
    - 생성일, 댓글 수, 좋아요 수, 조회 수 기준 정렬
    - 페이지네이션 적용
    - PostSortType enum을 통한 정렬 조건 추상화

## ✅ 체크리스트
- [x] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항
- 현재 사용자 인증은 하드코딩된 userId로 처리되어 있으며, 추후 Spring Security 적용 시 @AuthenticationPrincipal로 대체 예정
- 가맹점 삭제 시 게시글 처리 정책은 추후 비즈니스 정책에 따라 결정 필요

## 📎 관련 이슈
Close #14 